### PR TITLE
docs: changelog v2.0.0 y version bump

### DIFF
--- a/docs/changelog.de.md
+++ b/docs/changelog.de.md
@@ -5,12 +5,45 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 und dieses Projekt hält sich an [Semantische Versionierung](https://semver.org/spec/v2.0.0.html).
 
-## [Unveröffentlicht]
+## [2.0.0] - 2026-04-02
 
-### Geplant
-- Leistungsoptimierungen für Batch-Operationen
-- Zusätzliche Abfrageoperatoren und Filter
-- Verbesserte Fehlerbehandlung und Debugging-Tools
+### Inkompatible Änderungen
+
+- **Primitive Dekoratoren**: `@Get`, `@Set`, `@Validate` ersetzen `@Mutate`, `@Column`, `@Serialize` (entfernt).
+- **`@Default`** von Get- in Set-Pipeline verschoben. Wird bei Konstruktion aufgelöst, nicht beim Lesen.
+- **`@PrimaryKey`** generiert ULID statt UUID. Validiert ULID-Format. Unveränderlich nach erster Zuweisung.
+- **`@NotNull`** ist Komposition von `@Validate`. `store.nullable` aus Schema entfernt.
+- **`@UpdatedAt`** respektiert explizite Werte. Generiert `now()` nur wenn kein Wert übergeben wird.
+- **`@BelongsTo`** Signatur vereinheitlicht zu `(model, foreignKey, localKey)`, wie `@HasMany`/`@HasOne`.
+- **Set-Pipeline** Argumentreihenfolge von `(current, next)` zu `(next, current)` geändert.
+- **Konstruktor** führt Setter für alle Felder aus, nicht nur für in Props vorhandene.
+- **`connect()`** erstellt keine Tabellen mehr. Konfiguriert nur den DynamoDB-Client.
+- **Entfernt**: `withTrashed()`, `onlyTrashed()`, `relationDecorator()`, `@Column`, `@Mutate`, `@Serialize`.
+- **`where()`** wirft Fehler wenn Feld nicht in `schema.columns` existiert.
+
+### Hinzugefügt
+
+- **`sync()`**: erstellt Tabellen, GSIs und Pivot-Tabellen. Erkennt GSIs automatisch aus Relationen. Parallele Operationen mit Polling.
+- **Intelligentes `where()`**: `QueryCommand` mit PK oder GSI, Fallback zu `ScanCommand`. Self-Healing wenn GSI nicht existiert.
+- **`connect()`** berechnet erwartete GSIs aus Schemas ohne API-Aufrufe.
+- **`update()`/`delete()` PK-Optimierung**: direktes `GetItemCommand`/`DeleteItemCommand`.
+- **`increment()`/`decrement()`**: atomar via `UpdateItemCommand`. Statisch, Instanz und transaktional.
+- **`create()` Eindeutigkeit**: `ConditionExpression: attribute_not_exists(pk)`.
+- **ULID**: interner Generator ohne Abhängigkeiten. Monoton, sequentiell, lexikographisch sortierbar.
+- **Transaktionen**: `addUpdate()`, `onCommit()`, `__isPersisted` nach Commit, Auto-Chunking in 25er-Batches.
+- **Typisierung**: `Schema` mit echten Typen. `WhereOptions` mit rekursivem typisierten `include`. `PickByType<T, V>`. `order` akzeptiert Objekte.
+
+### Behoben
+
+- `@CreatedAt` setzt jetzt `store.createdAt = true` für Standard-Sortierung.
+- Relationen-Cache vereinfacht mit Dirty-Flag.
+- `processIncludes` weist via Setter zu.
+- `_mapPropertiesToDB` entfernt (toter Code).
+- `where()` Normalisierung vereinheitlicht.
+
+### Tests
+
+- 165 Tests gegen DynamoDB Local: Dekoratoren, CRUD, rekursive Relationen, ManyToMany, kombinierte Filter, Bulk 3000, Query vs Scan, Pipeline-Verträge, PK-Unveränderlichkeit, PK-Duplikate, ULID-Sequenzialität.
 
 ---
 

--- a/docs/changelog.es.md
+++ b/docs/changelog.es.md
@@ -5,12 +5,45 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Versionado Semántico](https://semver.org/spec/v2.0.0.html).
 
-## [Sin Publicar]
+## [2.0.0] - 2026-04-02
 
-### Planificado
-- Optimizaciones de rendimiento para operaciones en lote
-- Operadores y filtros de consulta adicionales
-- Herramientas mejoradas de manejo de errores y depuración
+### Cambios Incompatibles
+
+- **Decoradores primitivos**: `@Get`, `@Set`, `@Validate` reemplazan a `@Mutate`, `@Column`, `@Serialize` (eliminados).
+- **`@Default`** movido del get al set pipeline. Se resuelve en la construccion, no en la lectura.
+- **`@PrimaryKey`** genera ULID en vez de UUID. Valida formato ULID. Inmutable despues de la primera asignacion.
+- **`@NotNull`** es composicion de `@Validate`. Eliminado `store.nullable` del schema.
+- **`@UpdatedAt`** respeta valores explicitos. Solo genera `now()` cuando no se pasa valor.
+- **`@BelongsTo`** firma unificada a `(model, foreignKey, localKey)`, igual que `@HasMany`/`@HasOne`.
+- **Set pipeline** orden de argumentos cambiado de `(current, next)` a `(next, current)`.
+- **Constructor** ejecuta setters para todos los campos, no solo los presentes en props.
+- **`connect()`** ya no crea tablas. Solo configura el cliente DynamoDB.
+- **Eliminados**: `withTrashed()`, `onlyTrashed()`, `relationDecorator()`, `@Column`, `@Mutate`, `@Serialize`.
+- **`where()`** lanza error si el campo no existe en `schema.columns`.
+
+### Agregado
+
+- **`sync()`**: crea tablas, GSIs y pivot tables. Detecta GSIs desde relaciones. Operaciones en paralelo con polling.
+- **`where()` inteligente**: `QueryCommand` con PK o GSI, fallback a `ScanCommand`. Self-healing si GSI no existe.
+- **`connect()`** computa GSIs esperados desde schemas sin llamadas API.
+- **`update()`/`delete()` por PK**: `GetItemCommand`/`DeleteItemCommand` directo.
+- **`increment()`/`decrement()`**: atomicos con `UpdateItemCommand`. Estatico, instancia y transaccional.
+- **`create()` con unicidad**: `ConditionExpression: attribute_not_exists(pk)`.
+- **ULID**: generador interno sin dependencias. Monotónico, secuencial, lexicograficamente ordenable.
+- **Transacciones**: `addUpdate()`, `onCommit()`, `__isPersisted` post-commit, auto-chunking en lotes de 25.
+- **Tipado**: `Schema` con tipos reales. `WhereOptions` con `include` recursivo. `PickByType<T, V>`. `order` acepta objetos.
+
+### Corregido
+
+- `@CreatedAt` setea `store.createdAt = true` para sort default.
+- Cache de relaciones simplificado con dirty flag.
+- `processIncludes` asigna via setter.
+- `_mapPropertiesToDB` eliminado (dead code).
+- Normalización de `where()` unificada.
+
+### Tests
+
+- 165 tests contra DynamoDB Local: decoradores, CRUD, relaciones recursivas, ManyToMany, filtros combinados, bulk 3000, Query vs Scan, contratos de pipeline, PK immutability, PK duplicado, ULID secuencialidad.
 
 ---
 
@@ -206,7 +239,8 @@ Esta es una versión estable de @arcaelas/dynamite - un ORM moderno basado en de
 
 ## Resumen del Historial de Versiones
 
-- **v1.0.23** (Actual) - Corrección de enlaces de documentación, anclas TOC, consistencia multilingüe
+- **v2.0.0** (Actual) - Reestructuración completa: decoradores primitivos, ULID, Query inteligente, sync(), transacciones mejoradas
+- **v1.0.23** - Corrección de enlaces de documentación, anclas TOC, consistencia multilingüe
 - **v1.0.20** - Reestructuración de documentación, optimización del código base, creación de API.md
 - **v1.0.17** - Agregado @Serialize, @DeleteAt, transacciones Dynamite.tx()
 - **v1.0.13** - Versión estable con conjunto completo de características

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,12 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-04-02
 
-### Planned
-- Performance optimizations for batch operations
-- Additional query operators and filters
-- Improved error handling and debugging tools
+### Breaking Changes
+
+- **Primitive decorators**: `@Get`, `@Set`, `@Validate` replace `@Mutate`, `@Column`, `@Serialize` (removed).
+- **`@Default`** moved from get to set pipeline. Resolves at construction, not at read time.
+- **`@PrimaryKey`** generates ULID instead of UUID. Validates ULID format. Immutable after first assignment.
+- **`@NotNull`** is composition of `@Validate`. Removed `store.nullable` from schema.
+- **`@UpdatedAt`** respects explicit values. Only generates `now()` when no value is passed.
+- **`@BelongsTo`** signature unified to `(model, foreignKey, localKey)`, same as `@HasMany`/`@HasOne`.
+- **Set pipeline** argument order changed from `(current, next)` to `(next, current)`.
+- **Constructor** runs setters for all fields, not just those present in props.
+- **`connect()`** no longer creates tables. Only configures the DynamoDB client.
+- **Removed**: `withTrashed()`, `onlyTrashed()`, `relationDecorator()`, `@Column`, `@Mutate`, `@Serialize`.
+- **`where()`** throws error if field does not exist in `schema.columns`.
+
+### Added
+
+- **`sync()`**: creates tables, GSIs and pivot tables. Auto-detects GSIs from relations. Parallel operations with polling.
+- **Smart `where()`**: `QueryCommand` with PK or GSI, fallback to `ScanCommand`. Self-healing if GSI doesn't exist.
+- **`connect()`** computes expected GSIs from schemas without API calls.
+- **`update()`/`delete()` PK optimization**: direct `GetItemCommand`/`DeleteItemCommand`.
+- **`increment()`/`decrement()`**: atomic via `UpdateItemCommand`. Static, instance and transactional.
+- **`create()` uniqueness**: `ConditionExpression: attribute_not_exists(pk)`.
+- **ULID**: internal generator, no dependencies. Monotonic, sequential, lexicographically sortable.
+- **Transactions**: `addUpdate()`, `onCommit()`, `__isPersisted` post-commit, auto-chunking in batches of 25.
+- **Typing**: `Schema` with real types. `WhereOptions` with recursive typed `include`. `PickByType<T, V>`. `order` accepts objects.
+
+### Fixed
+
+- `@CreatedAt` now sets `store.createdAt = true` for default sort.
+- Relation cache simplified with dirty flag.
+- `processIncludes` assigns via setter.
+- `_mapPropertiesToDB` removed (dead code).
+- `where()` normalization unified.
+
+### Tests
+
+- 165 tests against DynamoDB Local: decorators, CRUD, recursive relations, ManyToMany, combined filters, bulk 3000, Query vs Scan, pipeline contracts, PK immutability, PK duplicates, ULID sequentiality.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
     "prepublishOnly": "yarn build",
     "postpublish": "find src -type f \\( -name '*.js' -o -name '*.d.ts' -o -name '*.map' \\) -delete"
   },
-  "version": "1.0.29"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Resumen
- Changelogs actualizados (EN/ES/DE) con todos los cambios de v2.0.0
- Version bump de 1.0.29 a 2.0.0 en package.json

Closes #18