### PR TITLE
feat: hooks de ciclo de vida y opciones de mutación unificadas (3.0.0)

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ Dynamite es un ORM para DynamoDB basado en decoradores TypeScript que proporcion
 6. [Schema avanzado con relaciones](#6-schema-avanzado-con-relaciones)
 7. [Metodos estaticos](#7-metodos-estaticos)
 8. [Metodos de instancia](#8-metodos-de-instancia)
+9. [Hooks de ciclo de vida](#9-hooks-de-ciclo-de-vida)
 
 ---
 
@@ -120,15 +121,15 @@ Los decoradores se ejecutan de abajo hacia arriba (el mas cercano a la propiedad
 ```typescript
 class Example extends Table<Example> {
   @Validate((v) => v <= 100 || "Max 100")  // Ejecuta tercero
-  @Mutate((v) => Math.abs(v))              // Ejecuta segundo
+  @Set((v) => Math.abs(v))                  // Ejecuta segundo
   @NotNull("Requerido")                     // Ejecuta primero
   value!: number;
 }
 
-// Flujo: NotNull -> Mutate -> Validate
+// Flujo: NotNull -> Set -> Validate
 // Input: -50
 // 1. NotNull: -50 (pasa, no es null)
-// 2. Mutate: 50 (valor absoluto)
+// 2. Set: 50 (valor absoluto)
 // 3. Validate: 50 (pasa, <= 100)
 ```
 
@@ -388,23 +389,45 @@ await user.forceDestroy();
 
 ### Decoradores de Transformacion
 
-#### @Column()
+#### @Get(transformFn)
 
-Marca explicitamente una propiedad como columna de base de datos.
+Pipeline de salida: transforma el valor al leerlo. Firma: `(value) => any`. No es necesario `@Column`: cualquier propiedad declarada ya es una columna.
 
 ```typescript
-import { Column } from "./decorators/transforms";
+import { Get } from "@arcaelas/dynamite";
 
-class Product extends Table<Product> {
+class User extends Table<User> {
   @PrimaryKey()
-  id!: string;
+  declare id: string;
 
-  @Column()
-  price!: number;
-
-  @Column()
-  category_id!: string;
+  // Almacenado en minusculas, expuesto en mayusculas al leer
+  @Get((v) => typeof v === "string" ? v.toUpperCase() : v)
+  declare name: string;
 }
+```
+
+#### @Set(transformFn)
+
+Pipeline de entrada: transforma el valor al asignarlo o guardarlo. Firma: `(next, current) => any`.
+
+```typescript
+import { Set } from "@arcaelas/dynamite";
+
+class User extends Table<User> {
+  @PrimaryKey()
+  declare id: string;
+
+  @Set((next) => typeof next === "string" ? next.toLowerCase().trim() : next)
+  declare email: string;
+
+  @Set((next) => typeof next === "string" ? parseInt(next, 10) : next)
+  declare age: number;
+}
+
+// Uso
+const user = await User.create({ email: "  JUAN@EXAMPLE.COM  ", age: "25" });
+console.log(user.email); // "juan@example.com"
+console.log(user.age);   // 25 (number)
 ```
 
 #### @Default(valor | funcion)
@@ -416,7 +439,6 @@ import { Default } from "./decorators/transforms";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => `user-${Date.now()}`)
   id!: string;
 
   @Default(18)
@@ -436,33 +458,6 @@ console.log(user.age); // 18
 - Valor estatico: `@Default("activo")`
 - Funcion generadora: `@Default(() => uuid())`
 - Timestamp: `@Default(() => Date.now())`
-
-#### @Mutate(transformFn)
-
-Transforma el valor cada vez que se asigna.
-
-```typescript
-import { Mutate } from "./decorators/transforms";
-
-class User extends Table<User> {
-  @PrimaryKey()
-  id!: string;
-
-  @Mutate((v) => v.toLowerCase().trim())
-  email!: string;
-
-  @Mutate((v) => typeof v === "string" ? parseInt(v, 10) : v)
-  age!: number;
-}
-
-// Uso
-const user = await User.create({
-  email: "  JUAN@EXAMPLE.COM  ",
-  age: "25"
-});
-console.log(user.email); // "juan@example.com"
-console.log(user.age);   // 25 (number)
-```
 
 #### @Validate(validador | validadores[])
 
@@ -499,27 +494,26 @@ try {
 }
 ```
 
-#### @Serialize(fromDB, toDB)
+#### Serializacion bidireccional (@Get + @Set)
 
-Transforma valores bidirecionalmente entre la aplicacion y la base de datos.
+Para transformar en ambos sentidos (lectura desde la BD con `@Get` y escritura hacia la BD con `@Set`) se combinan ambos decoradores sobre la misma propiedad.
 
 ```typescript
-import { Serialize } from "./decorators/transforms";
+import { Get, Set } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  id!: string;
+  declare id: string;
 
-  // JSON serialization
-  @Serialize(JSON.parse, JSON.stringify)
-  metadata!: Record<string, any>;
+  // JSON: objeto en la app, string en DynamoDB
+  @Get((v) => typeof v === "string" ? JSON.parse(v) : v)
+  @Set((next) => typeof next === "string" ? next : JSON.stringify(next))
+  declare metadata: Record<string, any>;
 
-  // Date serialization
-  @Serialize(
-    (v) => new Date(v),           // fromDB: string -> Date
-    (v) => v.toISOString()        // toDB: Date -> string
-  )
-  birth_date!: Date;
+  // Date: Date en la app, ISO string en DynamoDB
+  @Get((v) => typeof v === "string" ? new Date(v) : v)
+  @Set((next) => next instanceof Date ? next.toISOString() : next)
+  declare birth_date: Date;
 }
 
 // Uso
@@ -528,11 +522,10 @@ const user = await User.create({
   birth_date: new Date("1990-05-15")
 });
 
-// En la app: objeto/Date
 console.log(user.metadata.theme); // "dark"
-console.log(user.birth_date);     // Date object
+console.log(user.birth_date);     // Date
 
-// En DynamoDB: string serializado
+// En DynamoDB se almacena el string serializado:
 // { "metadata": "{\"theme\":\"dark\",\"lang\":\"es\"}" }
 ```
 
@@ -592,6 +585,51 @@ class User extends Table<User> {
 // En TypeScript: user.email
 // En DynamoDB: item.correo_electronico
 ```
+
+---
+
+### Decoradores de Hooks de ciclo de vida
+
+Marcan metodos de instancia que se ejecutan automaticamente alrededor de las operaciones de persistencia. Son **opt-in**: solo corren cuando la operacion recibe `{ hook: true }`. Dentro del hook, `this` es la entidad.
+
+| Decorador | Cuando se ejecuta | Argumento |
+|-----------|-------------------|-----------|
+| `@BeforeCreate()` | Antes de insertar. Puede mutar `this`. | - |
+| `@AfterCreate()` | Despues de insertar (`this` ya persistido). | - |
+| `@BeforeUpdate()` | Antes de actualizar. | `changes` (delta) |
+| `@AfterUpdate()` | Despues de actualizar. | `changes` (delta) |
+| `@BeforeDestroy()` | Antes de eliminar. | - |
+| `@AfterDestroy()` | Despues de eliminar. | - |
+
+```typescript
+import { Table, PrimaryKey, BeforeCreate, AfterCreate, BeforeUpdate } from "@arcaelas/dynamite";
+
+class User extends Table<User> {
+  @PrimaryKey() declare id: string;
+  declare email: string;
+  declare slug: string;
+
+  @BeforeCreate()
+  normalize() {
+    this.email = this.email.toLowerCase();
+    this.slug = this.email.split("@")[0];
+  }
+
+  @AfterCreate()
+  async welcome() {
+    await mailer.send(this.email, "Bienvenido");
+  }
+
+  @BeforeUpdate()
+  audit(changes: Partial<User>) {
+    console.log("campos modificados:", Object.keys(changes));
+  }
+}
+```
+
+- Se pueden declarar varios hooks del mismo tipo; se ejecutan en orden de declaracion.
+- Los hooks pueden ser `async`; se esperan con `await`.
+- Ver la seccion [9. Hooks de ciclo de vida](#9-hooks-de-ciclo-de-vida) para el detalle de ejecucion.
 
 ---
 
@@ -677,8 +715,8 @@ await dynamite.connect();
 
 ```typescript
 await dynamite.tx(async (tx) => {
-  const user = await User.create({ name: "Juan" }, tx);
-  await Order.create({ user_id: user.id, total: 100 }, tx);
+  const user = await User.create({ name: "Juan" }, { tx });
+  await Order.create({ user_id: user.id, total: 100 }, { tx });
   // Si alguna operacion falla, todas se revierten
 });
 ```
@@ -701,7 +739,6 @@ class Role extends Table<Role> {
    * @description Identificador unico del rol
    */
   @PrimaryKey()
-  @Default(() => `role-${Date.now()}`)
   id!: string;
 
   /**
@@ -749,7 +786,7 @@ import Table from "./core/table";
 import { PrimaryKey } from "./decorators/indexes";
 import { HasOne, HasMany, ManyToMany } from "./decorators/relations";
 import { CreatedAt, UpdatedAt } from "./decorators/timestamps";
-import { Default, NotNull, Validate, Mutate } from "./decorators/transforms";
+import { Default, NotNull, Validate, Set } from "./decorators/transforms";
 import type { CreationOptional, NonAttribute } from "./@types/index";
 import Profile from "./Profile";
 import Order from "./Order";
@@ -761,7 +798,6 @@ class User extends Table<User> {
    * @description Identificador unico del usuario
    */
   @PrimaryKey()
-  @Default(() => `user-${Date.now()}`)
   id!: string;
 
   /**
@@ -775,7 +811,7 @@ class User extends Table<User> {
    * @description Email del usuario (normalizado a minusculas)
    */
   @Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) || "Email invalido")
-  @Mutate((v) => v.toLowerCase().trim())
+  @Set((v) => v.toLowerCase().trim())
   email!: string;
 
   /**
@@ -832,7 +868,6 @@ export default User;
 @Name("profiles")
 class Profile extends Table<Profile> {
   @PrimaryKey()
-  @Default(() => `profile-${Date.now()}`)
   id!: string;
 
   user_id!: string;
@@ -849,7 +884,6 @@ class Profile extends Table<Profile> {
 @Name("orders")
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => `order-${Date.now()}`)
   id!: string;
 
   user_id!: string;
@@ -915,7 +949,7 @@ import Table from "./core/table";
 import { PrimaryKey, IndexSort } from "./decorators/indexes";
 import { HasOne, HasMany, BelongsTo, ManyToMany } from "./decorators/relations";
 import { CreatedAt, UpdatedAt, DeleteAt } from "./decorators/timestamps";
-import { Default, NotNull, Validate, Mutate, Serialize, Name, Column } from "./decorators/transforms";
+import { Default, NotNull, Validate, Get, Set, Name } from "./decorators/transforms";
 import type { CreationOptional, NonAttribute } from "./@types/index";
 
 // ============================================
@@ -924,11 +958,10 @@ import type { CreationOptional, NonAttribute } from "./@types/index";
 @Name("categories")
 class Category extends Table<Category> {
   @PrimaryKey()
-  @Default(() => `cat-${Date.now()}`)
   id!: string;
 
   @NotNull()
-  @Mutate((v) => v.toLowerCase().trim())
+  @Set((v) => v.toLowerCase().trim())
   name!: string;
 
   @HasMany(() => Product, "category_id", "id")
@@ -941,7 +974,6 @@ class Category extends Table<Category> {
 @Name("tags")
 class Tag extends Table<Tag> {
   @PrimaryKey()
-  @Default(() => `tag-${Date.now()}`)
   id!: string;
 
   @NotNull()
@@ -957,7 +989,6 @@ class Tag extends Table<Tag> {
 @Name("products")
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => `prod-${Date.now()}`)
   id!: string;
 
   @NotNull("El nombre del producto es requerido")
@@ -965,7 +996,7 @@ class Product extends Table<Product> {
   name!: string;
 
   @Validate((v) => v >= 0 || "El precio no puede ser negativo")
-  @Mutate((v) => Math.round(v * 100) / 100)  // Redondear a 2 decimales
+  @Set((v) => Math.round(v * 100) / 100)  // Redondear a 2 decimales
   @NotNull("El precio es requerido")
   price!: number;
 
@@ -973,11 +1004,11 @@ class Product extends Table<Product> {
   @Validate((v) => v >= 0 || "Stock no puede ser negativo")
   stock!: number;
 
-  @Serialize(JSON.parse, JSON.stringify)
+  @Get((v) => typeof v === "string" ? JSON.parse(v) : v)
+  @Set((next) => typeof next === "string" ? next : JSON.stringify(next))
   metadata?: Record<string, any>;
 
   @Name("cat_id")
-  @Column()
   category_id!: string;
 
   owner_id!: string;
@@ -1018,7 +1049,6 @@ class Product extends Table<Product> {
 @Name("product_images")
 class ProductImage extends Table<ProductImage> {
   @PrimaryKey()
-  @Default(() => `img-${Date.now()}`)
   id!: string;
 
   product_id!: string;
@@ -1039,7 +1069,6 @@ class ProductImage extends Table<ProductImage> {
 @Name("reviews")
 class Review extends Table<Review> {
   @PrimaryKey()
-  @Default(() => `review-${Date.now()}`)
   id!: string;
 
   product_id!: string;
@@ -1225,9 +1254,9 @@ const users = await User.where({ status: "active" }, {
 });
 ```
 
-### create(data, tx?)
+### create(data, options?)
 
-Crea un nuevo registro.
+Crea un nuevo registro. `options`: `{ hook?: boolean; tx?: TransactionContext }`.
 
 ```typescript
 // Creacion simple
@@ -1236,16 +1265,19 @@ const user = await User.create({
   email: "juan@example.com"
 });
 
-// Con transaccion
+// Con hooks de ciclo de vida (opt-in)
+const hooked = await User.create({ name: "Juan" }, { hook: true });
+
+// Con transaccion (tx ahora va dentro de options)
 await dynamite.tx(async (tx) => {
-  const user = await User.create({ name: "Juan" }, tx);
-  const order = await Order.create({ user_id: user.id, total: 100 }, tx);
+  const user = await User.create({ name: "Juan" }, { tx });
+  const order = await Order.create({ user_id: user.id, total: 100 }, { tx });
 });
 ```
 
-### update(cambios, filtros, tx?)
+### update(cambios, filtros, options?)
 
-Actualiza multiples registros que coincidan con los filtros.
+Actualiza multiples registros que coincidan con los filtros. `options`: `{ hook?: boolean; tx?: TransactionContext }`.
 
 ```typescript
 // Actualizar todos los usuarios inactivos
@@ -1255,20 +1287,26 @@ const affected = await User.update(
 );
 console.log(`${affected} usuarios actualizados`);
 
+// Con hooks: beforeUpdate/afterUpdate corren una vez por entidad afectada
+await User.update({ status: "active" }, { role: "admin" }, { hook: true });
+
 // Con transaccion
 await dynamite.tx(async (tx) => {
-  await User.update({ status: "active" }, { id: "user-1" }, tx);
+  await User.update({ status: "active" }, { id: "user-1" }, { tx });
 });
 ```
 
-### delete(filtros, tx?)
+### delete(filtros, options?)
 
-Elimina registros que coincidan con los filtros.
+Elimina registros que coincidan con los filtros. `options`: `{ hook?: boolean; tx?: TransactionContext }`.
 
 ```typescript
 // Eliminar usuarios suspendidos
 const deleted = await User.delete({ status: "suspended" });
 console.log(`${deleted} usuarios eliminados`);
+
+// Con hooks: beforeDestroy/afterDestroy corren una vez por entidad
+await User.delete({ status: "suspended" }, { hook: true });
 
 // Con soft delete: marca deleted_at en lugar de eliminar
 // (si el schema tiene @DeleteAt)
@@ -1334,9 +1372,9 @@ const deletedAdmins = await User.onlyTrashed({ role: "admin" });
 
 Los metodos de instancia operan sobre un registro especifico.
 
-### save()
+### save(options?)
 
-Inserta o actualiza el registro en la base de datos.
+Inserta o actualiza el registro en la base de datos. Acepta `{ hook?, tx? }`; con `hook: true` dispara los hooks de create (registro nuevo) o de update (registro persistido).
 
 ```typescript
 // Crear nuevo registro
@@ -1350,9 +1388,9 @@ user.name = "Juan Carlos";
 await user.save(); // UPDATE
 ```
 
-### update(cambios)
+### update(cambios, options?)
 
-Actualiza propiedades especificas del registro.
+Actualiza propiedades especificas del registro. Acepta `{ hook?, tx? }`; con `hook: true` los hooks `beforeUpdate`/`afterUpdate` corren sobre esta instancia y reciben el delta de cambios.
 
 ```typescript
 const user = await User.first({ id: "user-1" });
@@ -1369,9 +1407,9 @@ await user.update({
 // await user.save();
 ```
 
-### destroy()
+### destroy(options?)
 
-Elimina el registro. Si el schema tiene `@DeleteAt`, realiza soft delete.
+Elimina el registro. Si el schema tiene `@DeleteAt`, realiza soft delete. Acepta `{ hook?, tx? }`; con `hook: true` dispara `beforeDestroy`/`afterDestroy` sobre esta instancia (tambien en soft delete).
 
 ```typescript
 const user = await User.first({ id: "user-1" });
@@ -1385,9 +1423,9 @@ await user.destroy();
 // El registro se elimina permanentemente
 ```
 
-### forceDestroy()
+### forceDestroy(options?)
 
-Elimina permanentemente el registro, ignorando soft delete.
+Elimina permanentemente el registro, ignorando soft delete. Acepta `{ hook?, tx? }`; con `hook: true` dispara `beforeDestroy`/`afterDestroy`.
 
 ```typescript
 const user = await User.first({ id: "user-1" });
@@ -1481,3 +1519,49 @@ const user = await User.first({ id: "user-1" });
 console.log(user.toString());
 // "[User user-1]"
 ```
+
+---
+
+## 9. Hooks de ciclo de vida
+
+Los hooks permiten ejecutar logica alrededor de `create`, `update` y `destroy`. Se declaran con los decoradores de metodo `@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy` y `@AfterDestroy` (ver [seccion 2](#decoradores-de-hooks-de-ciclo-de-vida)). Se activan por operacion con el flag `hook`; por defecto **no** se ejecutan.
+
+### Activacion (opt-in)
+
+```typescript
+await User.create(data);                  // sin hooks
+await User.create(data, { hook: true });  // ejecuta beforeCreate + afterCreate
+
+await user.update({ name: "Ana" }, { hook: true });
+await user.destroy({ hook: true });
+```
+
+### Argumentos
+
+Cada hook es un metodo de instancia; `this` es la entidad. Los hooks de update reciben ademas el delta de cambios:
+
+| Hook | `this` | Argumento |
+|------|--------|-----------|
+| beforeCreate / afterCreate | instancia | - |
+| beforeUpdate / afterUpdate | instancia | `changes` |
+| beforeDestroy / afterDestroy | instancia | - |
+
+`@BeforeCreate` puede mutar `this` antes de persistir (normalizar campos, derivar valores). Si se declaran varios hooks del mismo tipo, se ejecutan en orden de declaracion.
+
+### Operaciones masivas
+
+En `User.update(cambios, filtros, { hook: true })` y `User.delete(filtros, { hook: true })`, los hooks corren **una vez por cada entidad** afectada. Con hooks de destroy activos, `delete` por clave primaria carga primero la fila para poder ejecutarlos.
+
+### Transacciones
+
+El flag `hook` se combina con `tx` en el mismo objeto de opciones. Los hooks `before*` corren al encolar la operacion; los `after*` se ejecutan despues del commit:
+
+```typescript
+await dynamite.tx(async (tx) => {
+  await User.create(data, { hook: true, tx });
+});
+// beforeCreate corrio dentro del create; afterCreate corre tras el commit
+```
+
+> `increment()` y `decrement()` aceptan `{ tx }` pero no disparan hooks.
+> Con `@DeleteAt` (soft delete), `destroy({ hook: true })` ejecuta los hooks de destroy aunque el registro solo se marque como eliminado.

--- a/docs/changelog.de.md
+++ b/docs/changelog.de.md
@@ -5,6 +5,17 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 und dieses Projekt hält sich an [Semantische Versionierung](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-06-06
+
+### Inkompatible Änderungen
+
+- **Vereinheitlichte Mutations-Optionen**: Die statischen Methoden `create`, `update`, `delete`, `increment`, `decrement` sowie die Instanzmethoden `save`, `update`, `destroy`, `forceDestroy` erhalten als letztes Argument ein `options`-Objekt vom Typ `MutationOptions = { hook?: boolean; tx?: TransactionContext }`. Das positionelle `tx`-Argument wurde entfernt. Vorher: `User.create(data, tx)` → jetzt: `User.create(data, { tx })`. Vorher: `order.destroy(tx)` → jetzt: `order.destroy({ tx })`.
+
+### Hinzugefügt
+
+- **Lifecycle-Hooks**: Sechs neue Methoden-Dekoratoren für Instanzen — `@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy`, `@AfterDestroy`. Pro Operation opt-in über `{ hook: true }`. Innerhalb des Hooks ist `this` die Entität; die Update-Hooks erhalten das Delta als erstes Argument. Mehrere Hooks desselben Typs laufen in Deklarationsreihenfolge, async-Hooks werden awaited. Bei Massen-`update`/`delete` laufen die Hooks einmal pro betroffener Entität. `before*` läuft vor dem Persistieren, `after*` danach (in einer Transaktion nach dem Commit). `increment()`/`decrement()` akzeptieren `{ tx }`, lösen aber keine Hooks aus.
+- **`TransactionContext.onCommit`** akzeptiert jetzt async-Callbacks.
+
 ## [2.0.0] - 2026-04-02
 
 ### Inkompatible Änderungen
@@ -239,7 +250,8 @@ Dies ist eine stabile Version von @arcaelas/dynamite - ein modernes, Decorator-f
 
 ## Versionsverlauf-Zusammenfassung
 
-- **v1.0.23** (Aktuell) - Dokumentationslink-Korrekturen, TOC-Anker-Korrekturen, mehrsprachige Konsistenz
+- **v3.0.0** (Aktuell) - Lifecycle-Hooks (@Before/@After) und vereinheitlichte `{ hook, tx }`-Mutationsoptionen (Breaking: positionales `tx` entfernt)
+- **v1.0.23** - Dokumentationslink-Korrekturen, TOC-Anker-Korrekturen, mehrsprachige Konsistenz
 - **v1.0.20** - Dokumentationsumstrukturierung, Codebasis-Optimierung, API.md-Erstellung
 - **v1.0.17** - @Serialize, @DeleteAt, Dynamite.tx()-Transaktionen hinzugefügt
 - **v1.0.13** - Stabile Version mit vollständigem Funktionsumfang

--- a/docs/changelog.es.md
+++ b/docs/changelog.es.md
@@ -5,6 +5,19 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Versionado Semántico](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-06-06
+
+### Cambios Incompatibles
+
+- **Opciones de mutación unificadas**: los métodos de mutación (`create`, `update`, `delete`, `save`, `destroy`, `increment`, `decrement`) reciben un objeto `options` de tipo `{ hook?: boolean; tx?: TransactionContext }` como último argumento. Se eliminó el parámetro posicional `tx`; ahora se usa `{ tx }` (por ejemplo, `User.create(data, { tx })` y `order.destroy({ tx })`).
+
+### Agregado
+
+- **Lifecycle hooks**: seis decoradores de método de instancia (`@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy`, `@AfterDestroy`). Son opt-in por operación con `{ hook: true }`. Dentro del hook, `this` es la entidad y los hooks de actualización reciben el delta de cambios como primer argumento. Varios hooks del mismo tipo corren en orden de declaración y los async se esperan con `await`. En `update`/`delete` masivos corren una vez por entidad afectada. Los `before*` se ejecutan antes de persistir y los `after*` después (tras el commit dentro de una transacción). `increment()`/`decrement()` aceptan `{ tx }` pero no disparan hooks.
+- **`TransactionContext.onCommit`** ahora acepta callbacks async.
+
+---
+
 ## [2.0.0] - 2026-04-02
 
 ### Cambios Incompatibles
@@ -239,7 +252,8 @@ Esta es una versión estable de @arcaelas/dynamite - un ORM moderno basado en de
 
 ## Resumen del Historial de Versiones
 
-- **v2.0.0** (Actual) - Reestructuración completa: decoradores primitivos, ULID, Query inteligente, sync(), transacciones mejoradas
+- **v3.0.0** (Actual) - Hooks de ciclo de vida (@Before/@After) y opciones de mutación unificadas `{ hook, tx }` (breaking: se eliminó el `tx` posicional)
+- **v2.0.0** - Reestructuración completa: decoradores primitivos, ULID, Query inteligente, sync(), transacciones mejoradas
 - **v1.0.23** - Corrección de enlaces de documentación, anclas TOC, consistencia multilingüe
 - **v1.0.20** - Reestructuración de documentación, optimización del código base, creación de API.md
 - **v1.0.17** - Agregado @Serialize, @DeleteAt, transacciones Dynamite.tx()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-06-06
+
+### Breaking Changes
+
+- **Unified mutation options**: static `create`, `update`, `delete`, `increment`, `decrement` and instance `save`, `update`, `destroy`, `forceDestroy` now take a single `options` object as their last argument: `MutationOptions = { hook?: boolean; tx?: TransactionContext }`.
+- **Removed positional `tx`**: the transaction is now passed inside the options object. Replace the old trailing `tx` argument with `{ tx }` — for example `User.create(data, { tx })` and `order.destroy({ tx })`.
+
+### Added
+
+- **Lifecycle hooks**: six instance-method decorators — `@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy`, `@AfterDestroy`. Opt-in per operation with `{ hook: true }`. Inside a hook `this` is the entity instance; the update hooks receive the changes delta as their first argument. Multiple hooks of the same type run in declaration order and async hooks are awaited. In mass `update`/`delete` they run once per affected entity. `before*` hooks run before persisting and `after*` hooks run after (after commit inside a transaction). `increment()`/`decrement()` accept `{ tx }` but do not trigger hooks.
+- **`TransactionContext.onCommit`** now accepts async callbacks.
+
 ## [2.0.0] - 2026-04-02
 
 ### Breaking Changes
@@ -239,7 +251,8 @@ This is a stable release of @arcaelas/dynamite - a modern, decorator-first ORM f
 
 ## Version History Summary
 
-- **v1.0.23** (Current) - Documentation link fixes, TOC anchor corrections, multilingual consistency
+- **v3.0.0** (Current) - Lifecycle hooks (@Before/@After) and unified `{ hook, tx }` mutation options (breaking: positional `tx` removed)
+- **v1.0.23** - Documentation link fixes, TOC anchor corrections, multilingual consistency
 - **v1.0.20** - Documentation restructure, codebase optimization, API.md creation
 - **v1.0.17** - Added @Serialize, @DeleteAt, Dynamite.tx() transactions
 - **v1.0.13** - Stable release with full feature set

--- a/docs/examples/advanced.de.md
+++ b/docs/examples/advanced.de.md
@@ -42,13 +42,11 @@ Verwenden Sie Vergleichsoperatoren für numerische und Datumsvergleiche:
 import {
   Table,
   PrimaryKey,
-  Default,
   CreationOptional
 } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -206,7 +204,7 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 }
 
@@ -531,7 +529,7 @@ import {
   Default,
   CreatedAt,
   UpdatedAt,
-  Mutate,
+  Set,
   CreationOptional,
   Dynamite
 } from "@arcaelas/dynamite";
@@ -539,12 +537,11 @@ import {
 // User-Modell
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 
   declare age: number;
@@ -559,7 +556,6 @@ class User extends Table<User> {
 // Product-Modell
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;

--- a/docs/examples/advanced.es.md
+++ b/docs/examples/advanced.es.md
@@ -48,7 +48,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -206,7 +205,7 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 }
 
@@ -561,7 +560,7 @@ import {
   CreatedAt,
   UpdatedAt,
   Validate,
-  Mutate,
+  Set,
   CreationOptional,
   Dynamite
 } from "@arcaelas/dynamite";
@@ -569,12 +568,11 @@ import {
 // Modelo User
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 
   declare age: number;
@@ -598,7 +596,6 @@ class User extends Table<User> {
 // Modelo Product
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -42,13 +42,11 @@ Use comparison operators for numeric and date comparisons:
 import {
   Table,
   PrimaryKey,
-  Default,
   CreationOptional
 } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -186,7 +184,7 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 }
 
@@ -541,7 +539,7 @@ import {
   CreatedAt,
   UpdatedAt,
   Validate,
-  Mutate,
+  Set,
   CreationOptional,
   Dynamite
 } from "@arcaelas/dynamite";
@@ -549,12 +547,11 @@ import {
 // User model
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
 
-  @Mutate((value) => (value as string).toLowerCase())
+  @Set((value) => (value as string).toLowerCase())
   declare email: string;
 
   declare age: number;
@@ -578,7 +575,6 @@ class User extends Table<User> {
 // Product model
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;

--- a/docs/examples/basic.de.md
+++ b/docs/examples/basic.de.md
@@ -33,7 +33,6 @@ import {
 class User extends Table<User> {
   // Automatisch generierter Primärschlüssel
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Erforderliches Feld bei Erstellung
@@ -407,7 +406,6 @@ import {
 // User-Modell definieren
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;

--- a/docs/examples/basic.es.md
+++ b/docs/examples/basic.es.md
@@ -33,7 +33,6 @@ import {
 class User extends Table<User> {
   // Clave primaria auto-generada
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Campo requerido durante la creación
@@ -452,7 +451,6 @@ import {
 // Definir modelo User
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -33,7 +33,6 @@ import {
 class User extends Table<User> {
   // Auto-generated primary key
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required field during creation
@@ -117,7 +116,7 @@ const user1 = await User.create({
   // id, role, active, timestamps are auto-generated
 });
 
-console.log(user1.id);         // "550e8400-e29b-41d4-a716-446655440000"
+console.log(user1.id);         // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 console.log(user1.name);       // "John Doe"
 console.log(user1.email);      // "john@example.com"
 console.log(user1.role);       // "customer" (default)
@@ -452,7 +451,6 @@ import {
 // Define User model first
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -604,9 +602,9 @@ When you run the complete example, you should see output similar to this:
 === User Management System ===
 
 1. Creating users...
-Created: John Doe (550e8400-e29b-41d4-a716-446655440000)
-Created: Jane Smith (6ba7b810-9dad-11d1-80b4-00c04fd430c8)
-Created: Bob Johnson (6ba7b811-9dad-11d1-80b4-00c04fd430c9)
+Created: John Doe (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+Created: Jane Smith (01ARZ3NDEKTSV4RRFFQ69G5FB0)
+Created: Bob Johnson (01ARZ3NDEKTSV4RRFFQ69G5FB1)
 
 2. Listing all users...
 Total users: 3

--- a/docs/examples/relations.de.md
+++ b/docs/examples/relations.de.md
@@ -57,7 +57,6 @@ Definieren Sie eine Eins-zu-Viele-Beziehung, bei der ein Elternmodell mehrere zu
 import {
   Table,
   PrimaryKey,
-  Default,
   HasMany,
   CreationOptional,
   NonAttribute
@@ -66,7 +65,6 @@ import {
 // User-Modell (Eltern)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -80,7 +78,6 @@ class User extends Table<User> {
 // Post-Modell (Kind)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Fremdschlüssel
@@ -123,7 +120,6 @@ Ein Modell kann mehrere Eins-zu-Viele-Beziehungen haben:
 ```typescript
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -166,7 +162,6 @@ Definieren Sie eine Viele-zu-Eins-Beziehung, bei der ein Kindmodell zu einem ein
 // Post-Modell (Kind)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Fremdschlüssel
@@ -181,7 +176,6 @@ class Post extends Table<Post> {
 // User-Modell (Eltern)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -332,7 +326,6 @@ Hier ist ein vollständiges E-Commerce-System, das alle Beziehungsmuster demonst
 import {
   Table,
   PrimaryKey,
-  Default,
   HasMany,
   BelongsTo,
   CreatedAt,
@@ -345,7 +338,6 @@ import {
 // User-Modell
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -362,7 +354,6 @@ class User extends Table<User> {
 // Product-Modell
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -379,7 +370,6 @@ class Product extends Table<Product> {
 // Order-Modell
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -399,7 +389,6 @@ class Order extends Table<Order> {
 // OrderItem-Modell
 class OrderItem extends Table<OrderItem> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare order_id: string;

--- a/docs/examples/relations.es.md
+++ b/docs/examples/relations.es.md
@@ -66,7 +66,6 @@ import {
 // Modelo User (padre)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -80,7 +79,6 @@ class User extends Table<User> {
 // Modelo Post (hijo)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Clave foránea
@@ -123,7 +121,6 @@ Un modelo puede tener múltiples relaciones uno-a-muchos:
 ```typescript
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -166,7 +163,6 @@ Define una relación muchos-a-uno donde un modelo hijo pertenece a un solo padre
 // Modelo Post (hijo)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Clave foránea
@@ -181,7 +177,6 @@ class Post extends Table<Post> {
 // Modelo User (padre)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -220,7 +215,6 @@ Un modelo hijo puede pertenecer a múltiples padres:
 ```typescript
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -462,7 +456,6 @@ import {
 // Modelo User
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -488,7 +481,6 @@ class User extends Table<User> {
 // Modelo Product
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -512,7 +504,6 @@ class Product extends Table<Product> {
 // Modelo Order
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -539,7 +530,6 @@ class Order extends Table<Order> {
 // Modelo OrderItem
 class OrderItem extends Table<OrderItem> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare order_id: string;
@@ -558,7 +548,6 @@ class OrderItem extends Table<OrderItem> {
 // Modelo Review
 class Review extends Table<Review> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;

--- a/docs/examples/relations.md
+++ b/docs/examples/relations.md
@@ -57,7 +57,6 @@ Define a one-to-many relationship where a parent model has multiple related chil
 import {
   Table,
   PrimaryKey,
-  Default,
   HasMany,
   CreationOptional,
   NonAttribute
@@ -66,7 +65,6 @@ import {
 // User model (parent)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -80,7 +78,6 @@ class User extends Table<User> {
 // Post model (child)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Foreign key
@@ -123,7 +120,6 @@ A model can have multiple one-to-many relationships:
 ```typescript
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -166,7 +162,6 @@ Define a many-to-one relationship where a child model belongs to a single parent
 // Post model (child)
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string; // Foreign key
@@ -181,7 +176,6 @@ class Post extends Table<Post> {
 // User model (parent)
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -220,7 +214,6 @@ A child model can belong to multiple parents:
 ```typescript
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -462,7 +455,6 @@ import {
 // User model
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -488,7 +480,6 @@ class User extends Table<User> {
 // Product model
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -512,7 +503,6 @@ class Product extends Table<Product> {
 // Order model
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -539,7 +529,6 @@ class Order extends Table<Order> {
 // OrderItem model
 class OrderItem extends Table<OrderItem> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare order_id: string;
@@ -558,7 +547,6 @@ class OrderItem extends Table<OrderItem> {
 // Review model
 class Review extends Table<Review> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -1059,8 +1047,8 @@ for (const post of posts) {
 
 ### API References
 
-- [HasMany Decorator](../references/decorators.md#hasmany-relaciones-uno-a-muchos) - Complete HasMany documentation
-- [BelongsTo Decorator](../references/decorators.md#belongsto-relaciones-muchos-a-uno) - Complete BelongsTo documentation
+- [HasMany Decorator](../references/decorators.md#hasmany-one-to-many-relationships) - Complete HasMany documentation
+- [BelongsTo Decorator](../references/decorators.md#belongsto-many-to-one-relationships) - Complete BelongsTo documentation
 - [Advanced Queries](./advanced.md) - Complex queries with relationships
 
 ### Additional Topics

--- a/docs/getting-started.de.md
+++ b/docs/getting-started.de.md
@@ -59,9 +59,8 @@ Lassen Sie uns ein einfaches Benutzermodell erstellen. In Dynamite sind Modelle 
 import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
-  // Primärschlüssel mit automatisch generierter UUID
+  // Primärschlüssel mit automatisch generierter ULID
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Erforderliches Feld während der Erstellung
@@ -295,7 +294,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -337,7 +335,7 @@ import {
   CreatedAt,
   UpdatedAt,
   Validate,
-  Mutate,
+  Set,
   NotNull,
   CreationOptional,
   NonAttribute,
@@ -348,12 +346,11 @@ import {
 class Task extends Table<Task> {
   // Automatisch generierte ID
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Erforderlicher Titel mit Validierung
   @NotNull()
-  @Mutate((value) => (value as string).trim())
+  @Set((value) => (value as string).trim())
   @Validate((value) => (value as string).length >= 3 || "Titel muss mindestens 3 Zeichen lang sein")
   declare title: string;
 
@@ -460,7 +457,6 @@ Lassen Sie uns die Schlüsselteile aufschlüsseln:
 ```typescript
 class Task extends Table<Task> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
   // ...
 }
@@ -479,10 +475,10 @@ declare title: string;
 
 ### Datentransformation
 ```typescript
-@Mutate((value) => (value as string).trim())
+@Set((value) => (value as string).trim())
 declare title: string;
 ```
-- Transformiert Daten vor dem Speichern
+- Transformiert Daten vor dem Schreiben in die Datenbank
 - Nützlich für Normalisierung (trim, lowercase, etc.)
 
 ### Berechnete Eigenschaften
@@ -520,7 +516,7 @@ Lernen Sie die grundlegenden Konzepte und Architektur kennen:
 - Verwenden Sie `CreationOptional` für Felder mit `@Default`, `@CreatedAt`, `@UpdatedAt`
 - Verwenden Sie `NonAttribute` für berechnete Eigenschaften
 - Validieren Sie Benutzereingaben mit `@Validate`
-- Transformieren Sie Daten mit `@Mutate` vor der Validierung
+- Transformieren Sie Daten beim Schreiben mit `@Set` und beim Lesen mit `@Get`
 - Verwenden Sie spezifische Attributauswahl, um Datenübertragung zu reduzieren
 - Behandeln Sie Fehler elegant mit Try-Catch-Blöcken
 
@@ -539,7 +535,8 @@ Lernen Sie die grundlegenden Konzepte und Architektur kennen:
 | `@CreatedAt()` | Auto-Zeitstempel bei Erstellung | `@CreatedAt() declare created_at: string` |
 | `@UpdatedAt()` | Auto-Zeitstempel bei Aktualisierung | `@UpdatedAt() declare updated_at: string` |
 | `@Validate(fn)` | Validierung | `@Validate((v) => v.length > 0) declare name: string` |
-| `@Mutate(fn)` | Daten transformieren | `@Mutate((v) => v.trim()) declare email: string` |
+| `@Get(fn)` | Transformation beim Lesen | `@Get((v) => new Date(v)) declare created_at: Date` |
+| `@Set(fn)` | Transformation beim Schreiben | `@Set((v) => v.trim()) declare email: string` |
 | `@NotNull()` | Nicht-Null-Prüfung | `@NotNull() declare email: string` |
 
 ### Wesentliche Typen

--- a/docs/getting-started.es.md
+++ b/docs/getting-started.es.md
@@ -61,7 +61,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 class User extends Table<User> {
   // Clave primaria con UUID autogenerado
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Campo requerido durante la creación
@@ -295,7 +294,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -337,7 +335,7 @@ import {
   CreatedAt,
   UpdatedAt,
   Validate,
-  Mutate,
+  Set,
   NotNull,
   CreationOptional,
   NonAttribute,
@@ -348,12 +346,11 @@ import {
 class Task extends Table<Task> {
   // ID autogenerado
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Título requerido con validación
   @NotNull()
-  @Mutate((value) => (value as string).trim())
+  @Set((value) => (value as string).trim())
   @Validate((value) => (value as string).length >= 3 || "El título debe tener al menos 3 caracteres")
   declare title: string;
 
@@ -566,7 +563,6 @@ Desglosemos las partes clave:
 ```typescript
 class Task extends Table<Task> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
   // ...
 }
@@ -585,7 +581,7 @@ declare title: string;
 
 ### Transformación de Datos
 ```typescript
-@Mutate((value) => (value as string).trim())
+@Set((value) => (value as string).trim())
 declare title: string;
 ```
 - Transforma datos antes del almacenamiento
@@ -626,7 +622,7 @@ Aprende sobre los conceptos fundamentales y la arquitectura:
 - Usa `CreationOptional` para campos con `@Default`, `@CreatedAt`, `@UpdatedAt`
 - Usa `NonAttribute` para propiedades computadas
 - Valida entrada del usuario con `@Validate`
-- Transforma datos con `@Mutate` antes de la validación
+- Transforma datos al escribir con `@Set` antes de la validación
 - Usa selección de atributos específicos para reducir transferencia de datos
 - Maneja errores con gracia usando bloques try-catch
 
@@ -645,7 +641,8 @@ Aprende sobre los conceptos fundamentales y la arquitectura:
 | `@CreatedAt()` | Auto timestamp en creación | `@CreatedAt() declare created_at: string` |
 | `@UpdatedAt()` | Auto timestamp en actualización | `@UpdatedAt() declare updated_at: string` |
 | `@Validate(fn)` | Validación | `@Validate((v) => v.length > 0) declare name: string` |
-| `@Mutate(fn)` | Transformar datos | `@Mutate((v) => v.trim()) declare email: string` |
+| `@Set(fn)` | Transformar al escribir | `@Set((v) => v.trim()) declare email: string` |
+| `@Get(fn)` | Transformar al leer | `@Get((v) => v.toUpperCase()) declare code: string` |
 | `@NotNull()` | Verificación no nulo | `@NotNull() declare email: string` |
 
 ### Tipos Esenciales

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,9 +59,8 @@ Let's create a simple User model. In Dynamite, models are classes that extend `T
 import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
-  // Primary key with auto-generated UUID
+  // Primary key with auto-generated ULID
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required field during creation
@@ -92,7 +91,7 @@ const user1 = await User.create({
   // id and role are optional (auto-generated/defaulted)
 });
 
-console.log(user1.id);   // "550e8400-e29b-41d4-a716-446655440000"
+console.log(user1.id);   // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 console.log(user1.name); // "John Doe"
 console.log(user1.role); // "customer"
 
@@ -298,7 +297,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -340,7 +338,7 @@ import {
   CreatedAt,
   UpdatedAt,
   Validate,
-  Mutate,
+  Set,
   NotNull,
   CreationOptional,
   NonAttribute,
@@ -351,12 +349,11 @@ import {
 class Task extends Table<Task> {
   // Auto-generated ID
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required title with validation
   @NotNull()
-  @Mutate((value) => (value as string).trim())
+  @Set((value) => (value as string).trim())
   @Validate((value) => (value as string).length >= 3 || "Title must be at least 3 characters")
   declare title: string;
 
@@ -569,7 +566,6 @@ Let's break down the key parts:
 ```typescript
 class Task extends Table<Task> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
   // ...
 }
@@ -588,7 +584,7 @@ declare title: string;
 
 ### Data Transformation
 ```typescript
-@Mutate((value) => (value as string).trim())
+@Set((value) => (value as string).trim())
 declare title: string;
 ```
 - Transforms data before storage
@@ -629,7 +625,7 @@ Learn about the fundamental concepts and architecture:
 - Use `CreationOptional` for fields with `@Default`, `@CreatedAt`, `@UpdatedAt`
 - Use `NonAttribute` for computed properties
 - Validate user input with `@Validate`
-- Transform data with `@Mutate` before validation
+- Transform data with `@Set` before validation
 - Use specific attribute selection to reduce data transfer
 - Handle errors gracefully with try-catch blocks
 
@@ -648,7 +644,8 @@ Learn about the fundamental concepts and architecture:
 | `@CreatedAt()` | Auto timestamp on create | `@CreatedAt() declare created_at: string` |
 | `@UpdatedAt()` | Auto timestamp on update | `@UpdatedAt() declare updated_at: string` |
 | `@Validate(fn)` | Validation | `@Validate((v) => v.length > 0) declare name: string` |
-| `@Mutate(fn)` | Transform data | `@Mutate((v) => v.trim()) declare email: string` |
+| `@Get(fn)` | Transform on read | `@Get((v) => JSON.parse(v)) declare data: object` |
+| `@Set(fn)` | Transform on write | `@Set((v) => v.trim()) declare email: string` |
 | `@NotNull()` | Not null check | `@NotNull() declare email: string` |
 
 ### Essential Types

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -15,6 +15,7 @@
 - **Validierung & Transformation** - Integrierte Decorators für Datenverarbeitung
 - **Soft Deletes** - @DeleteAt Decorator für wiederherstellbare Datensätze
 - **Transaktionen** - Volle Transaktionsunterstützung mit Rollback
+- **Lifecycle-Hooks** - Opt-in @Before/@After Hooks für create, update und destroy
 
 ---
 
@@ -26,7 +27,6 @@ import { Dynamite, Table, PrimaryKey, Default, CreatedAt } from '@arcaelas/dynam
 // Definiere dein Modell
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -70,7 +70,8 @@ await user.destroy();
 | `@Index()` | Globaler Sekundärindex |
 | `@Default(value)` | Standardwert (statisch oder Funktion) |
 | `@Validate(fn)` | Validierung beim Setzen |
-| `@Mutate(fn)` | Transformation beim Setzen |
+| `@Get(fn)` | Transformation beim Lesen |
+| `@Set(fn)` | Transformation beim Schreiben |
 | `@CreatedAt()` | Auto-Setzen beim Erstellen |
 | `@UpdatedAt()` | Auto-Setzen beim Aktualisieren |
 | `@DeleteAt()` | Soft Delete Zeitstempel |

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -15,6 +15,7 @@
 - **Validación y transformación** - Decoradores integrados para procesar datos
 - **Soft deletes** - Decorador @DeleteAt para registros recuperables
 - **Transacciones** - Soporte completo de transacciones con rollback
+- **Lifecycle hooks** - Decoradores @Before/@After opt-in para create, update y destroy
 
 ---
 
@@ -26,7 +27,6 @@ import { Dynamite, Table, PrimaryKey, Default, CreatedAt } from '@arcaelas/dynam
 // Define tu modelo
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -70,7 +70,8 @@ await user.destroy();
 | `@Index()` | Índice Secundario Global |
 | `@Default(value)` | Valor por defecto (estático o función) |
 | `@Validate(fn)` | Validación al asignar |
-| `@Mutate(fn)` | Transformación al asignar |
+| `@Set(fn)` | Transformación al escribir |
+| `@Get(fn)` | Transformación al leer |
 | `@CreatedAt()` | Auto-asignar al crear |
 | `@UpdatedAt()` | Auto-asignar al actualizar |
 | `@DeleteAt()` | Timestamp de soft delete |

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,18 +15,18 @@
 - **Validation & transformation** - Built-in decorators for data processing
 - **Soft deletes** - @DeleteAt decorator for recoverable records
 - **Transactions** - Full transaction support with rollback
+- **Lifecycle hooks** - Opt-in @Before/@After hooks for create, update and destroy
 
 ---
 
 ## Quick Start
 
 ```typescript
-import { Dynamite, Table, PrimaryKey, Default, CreatedAt } from '@arcaelas/dynamite';
+import { Dynamite, Table, PrimaryKey, CreatedAt } from '@arcaelas/dynamite';
 
 // Define your model
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -70,7 +70,8 @@ await user.destroy();
 | `@Index()` | Global Secondary Index |
 | `@Default(value)` | Default value (static or function) |
 | `@Validate(fn)` | Validation on set |
-| `@Mutate(fn)` | Transform on set |
+| `@Get(fn)` | Transform on read |
+| `@Set(fn)` | Transform on write |
 | `@CreatedAt()` | Auto-set on create |
 | `@UpdatedAt()` | Auto-set on update |
 | `@DeleteAt()` | Soft delete timestamp |

--- a/docs/installation.de.md
+++ b/docs/installation.de.md
@@ -398,7 +398,6 @@ import {
 
 export class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -445,7 +444,6 @@ class User extends Table {
 
 // Apply decorators
 PrimaryKey()(User.prototype, "id");
-Default(() => crypto.randomUUID())(User.prototype, "id");
 NotNull()(User.prototype, "name");
 NotNull()(User.prototype, "email");
 Default(() => "customer")(User.prototype, "role");
@@ -513,12 +511,11 @@ Erstellen Sie eine einfache Testdatei:
 import dotenv from "dotenv";
 dotenv.config();
 
-import { Dynamite, Table, PrimaryKey, Default } from "@arcaelas/dynamite";
+import { Dynamite, Table, PrimaryKey } from "@arcaelas/dynamite";
 
 // Definieren Sie ein Testmodell
 class TestModel extends Table<TestModel> {
   @PrimaryKey()
-  @Default(() => "test-id")
   declare id: string;
 }
 

--- a/docs/installation.es.md
+++ b/docs/installation.es.md
@@ -398,7 +398,6 @@ import {
 
 export class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -518,7 +517,6 @@ import { Dynamite, Table, PrimaryKey, Default } from "@arcaelas/dynamite";
 // Define un modelo de prueba
 class TestModel extends Table<TestModel> {
   @PrimaryKey()
-  @Default(() => "test-id")
   declare id: string;
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -398,7 +398,6 @@ import {
 
 export class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -445,7 +444,6 @@ class User extends Table {
 
 // Apply decorators
 PrimaryKey()(User.prototype, "id");
-Default(() => crypto.randomUUID())(User.prototype, "id");
 NotNull()(User.prototype, "name");
 NotNull()(User.prototype, "email");
 Default(() => "customer")(User.prototype, "role");
@@ -513,12 +511,11 @@ Create a simple test file:
 import dotenv from "dotenv";
 dotenv.config();
 
-import { Dynamite, Table, PrimaryKey, Default } from "@arcaelas/dynamite";
+import { Dynamite, Table, PrimaryKey } from "@arcaelas/dynamite";
 
 // Define a test model
 class TestModel extends Table<TestModel> {
   @PrimaryKey()
-  @Default(() => "test-id")
   declare id: string;
 }
 

--- a/docs/references/client.de.md
+++ b/docs/references/client.de.md
@@ -95,8 +95,8 @@ Executes operations within an atomic transaction. If any operation fails, all ch
 **Example:**
 ```typescript
 await dynamite.tx(async (tx) => {
-  const user = await User.create({ name: "John" }, tx);
-  await Order.create({ user_id: user.id, total: 100 }, tx);
+  const user = await User.create({ name: "John" }, { tx });
+  await Order.create({ user_id: user.id, total: 100 }, { tx });
   // If any create fails, all operations are rolled back
 });
 ```
@@ -207,11 +207,10 @@ await dynamite.connect();
 ## Complete Example
 
 ```typescript
-import { Dynamite, Table, PrimaryKey, Default, HasMany, NonAttribute } from "@arcaelas/dynamite";
+import { Dynamite, Table, PrimaryKey, HasMany, NonAttribute } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -222,7 +221,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare user_id: string;
@@ -241,8 +239,8 @@ async function main() {
 
   // Atomic transaction
   await dynamite.tx(async (tx) => {
-    const user = await User.create({ name: "John" }, tx);
-    await Order.create({ user_id: user.id, total: 99.99 }, tx);
+    const user = await User.create({ name: "John" }, { tx });
+    await Order.create({ user_id: user.id, total: 99.99 }, { tx });
   });
 
   // Query with relations

--- a/docs/references/client.es.md
+++ b/docs/references/client.es.md
@@ -95,8 +95,8 @@ Executes operations within an atomic transaction. If any operation fails, all ch
 **Example:**
 ```typescript
 await dynamite.tx(async (tx) => {
-  const user = await User.create({ name: "John" }, tx);
-  await Order.create({ user_id: user.id, total: 100 }, tx);
+  const user = await User.create({ name: "John" }, { tx });
+  await Order.create({ user_id: user.id, total: 100 }, { tx });
   // If any create fails, all operations are rolled back
 });
 ```
@@ -211,7 +211,6 @@ import { Dynamite, Table, PrimaryKey, Default, HasMany, NonAttribute } from "@ar
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -222,7 +221,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare user_id: string;
@@ -241,8 +239,8 @@ async function main() {
 
   // Atomic transaction
   await dynamite.tx(async (tx) => {
-    const user = await User.create({ name: "John" }, tx);
-    await Order.create({ user_id: user.id, total: 99.99 }, tx);
+    const user = await User.create({ name: "John" }, { tx });
+    await Order.create({ user_id: user.id, total: 99.99 }, { tx });
   });
 
   // Query with relations

--- a/docs/references/client.md
+++ b/docs/references/client.md
@@ -95,8 +95,8 @@ Executes operations within an atomic transaction. If any operation fails, all ch
 **Example:**
 ```typescript
 await dynamite.tx(async (tx) => {
-  const user = await User.create({ name: "John" }, tx);
-  await Order.create({ user_id: user.id, total: 100 }, tx);
+  const user = await User.create({ name: "John" }, { tx });
+  await Order.create({ user_id: user.id, total: 100 }, { tx });
   // If any create fails, all operations are rolled back
 });
 ```
@@ -207,11 +207,10 @@ await dynamite.connect();
 ## Complete Example
 
 ```typescript
-import { Dynamite, Table, PrimaryKey, Default, HasMany, NonAttribute } from "@arcaelas/dynamite";
+import { Dynamite, Table, PrimaryKey, HasMany, NonAttribute } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare name: string;
@@ -222,7 +221,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: string;
 
   declare user_id: string;
@@ -241,8 +239,8 @@ async function main() {
 
   // Atomic transaction
   await dynamite.tx(async (tx) => {
-    const user = await User.create({ name: "John" }, tx);
-    await Order.create({ user_id: user.id, total: 99.99 }, tx);
+    const user = await User.create({ name: "John" }, { tx });
+    await Order.create({ user_id: user.id, total: 99.99 }, { tx });
   });
 
   // Query with relations

--- a/docs/references/core-concepts.de.md
+++ b/docs/references/core-concepts.de.md
@@ -51,7 +51,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -100,7 +99,8 @@ Decorators sind spezielle Funktionen, die Klasseneigenschaften mit Metadaten ann
 | Decorator | Zweck | Beispiel |
 |-----------|-------|----------|
 | `@Default(value)` | Standardwert | `@Default(() => Date.now()) declare createdAt: number;` |
-| `@Mutate(fn)` | Vor Speichern transformieren | `@Mutate(v => v.toLowerCase()) declare email: string;` |
+| `@Get(fn)` | Beim Lesen transformieren | `@Get(v => new Date(v)) declare createdAt: Date;` |
+| `@Set(fn)` | Beim Schreiben transformieren | `@Set(v => v.toLowerCase()) declare email: string;` |
 | `@Validate(fn)` | Vor Speichern validieren | `@Validate(v => v.length > 0) declare name: string;` |
 | `@NotNull()` | Nicht-Null-Wert erfordern | `@NotNull() declare email: string;` |
 
@@ -125,7 +125,7 @@ import {
   Table,
   PrimaryKey,
   Default,
-  Mutate,
+  Set,
   Validate,
   NotNull,
   CreatedAt,
@@ -137,12 +137,11 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
-  @Mutate(v => v.trim())
-  @Mutate(v => v.toLowerCase())
+  @Set(v => v.trim())
+  @Set(v => v.toLowerCase())
   @Validate(v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) || "Ungültige E-Mail")
   declare email: string;
 
@@ -217,7 +216,6 @@ const recentOrders = await Order.where({
 ```typescript
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -230,7 +228,7 @@ const product = await Product.create({
   price: 9.99
 });
 
-console.log(product.id); // "550e8400-e29b-41d4-a716-446655440000"
+console.log(product.id); // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 ```
 
 ---
@@ -405,7 +403,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // Automatisch generierte ID - immer CreationOptional
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Erforderliche Felder

--- a/docs/references/core-concepts.es.md
+++ b/docs/references/core-concepts.es.md
@@ -51,7 +51,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -100,7 +99,8 @@ Los decoradores son funciones especiales que anotan propiedades de clase con met
 | Decorador | Propósito | Ejemplo |
 |-----------|---------|---------|
 | `@Default(value)` | Valor por defecto | `@Default(() => Date.now()) declare createdAt: number;` |
-| `@Mutate(fn)` | Transformar antes de guardar | `@Mutate(v => v.toLowerCase()) declare email: string;` |
+| `@Set(fn)` | Transformar al escribir | `@Set(v => v.toLowerCase()) declare email: string;` |
+| `@Get(fn)` | Transformar al leer | `@Get(v => v.toUpperCase()) declare code: string;` |
 | `@Validate(fn)` | Validar antes de guardar | `@Validate(v => v.length > 0) declare name: string;` |
 | `@NotNull()` | Requerir valor no nulo | `@NotNull() declare email: string;` |
 
@@ -125,7 +125,7 @@ import {
   Table,
   PrimaryKey,
   Default,
-  Mutate,
+  Set,
   Validate,
   NotNull,
   CreatedAt,
@@ -137,12 +137,11 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
-  @Mutate(v => v.trim())
-  @Mutate(v => v.toLowerCase())
+  @Set(v => v.trim())
+  @Set(v => v.toLowerCase())
   @Validate(v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) || "Email inválido")
   declare email: string;
 
@@ -217,7 +216,6 @@ const recentOrders = await Order.where({
 ```typescript
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -400,7 +398,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // ID autogenerado - siempre CreationOptional
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Campos requeridos

--- a/docs/references/core-concepts.md
+++ b/docs/references/core-concepts.md
@@ -51,7 +51,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -100,7 +99,8 @@ Decorators are special functions that annotate class properties with metadata. D
 | Decorator | Purpose | Example |
 |-----------|---------|---------|
 | `@Default(value)` | Default value | `@Default(() => Date.now()) declare created_at: number;` |
-| `@Mutate(fn)` | Transform before save | `@Mutate(v => v.toLowerCase()) declare email: string;` |
+| `@Get(fn)` | Transform on read | `@Get(v => JSON.parse(v)) declare data: object;` |
+| `@Set(fn)` | Transform on write | `@Set(v => v.toLowerCase()) declare email: string;` |
 | `@Validate(fn)` | Validate before save | `@Validate(v => v.length > 0) declare name: string;` |
 | `@NotNull()` | Require non-null value | `@NotNull() declare email: string;` |
 
@@ -127,7 +127,7 @@ import {
   Table,
   PrimaryKey,
   Default,
-  Mutate,
+  Set,
   Validate,
   NotNull,
   CreatedAt,
@@ -139,12 +139,11 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
-  @Mutate(v => v.trim())
-  @Mutate(v => v.toLowerCase())
+  @Set(v => v.trim())
+  @Set(v => v.toLowerCase())
   @Validate(v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) || "Invalid email")
   declare email: string;
 
@@ -219,7 +218,6 @@ const recentOrders = await Order.where({
 ```typescript
 class Product extends Table<Product> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -232,7 +230,7 @@ const product = await Product.create({
   price: 9.99
 });
 
-console.log(product.id); // "550e8400-e29b-41d4-a716-446655440000"
+console.log(product.id); // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 ```
 
 ---
@@ -501,7 +499,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // Auto-generated ID - always CreationOptional
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required fields
@@ -673,7 +670,6 @@ import {
 class User extends Table<User> {
   // Auto-generated (CreationOptional)
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required
@@ -749,10 +745,10 @@ Understanding how data flows through Dynamite helps you use it effectively. Here
 1. MODEL DEFINITION
    ┌────────────────────────────────────────────────────────┐
    │ class User extends Table<User> {                       │
-   │   @PrimaryKey() @Default(() => uuid())                 │
+   │   @PrimaryKey()                                         │
    │   declare id: CreationOptional<string>;                │
    │                                                         │
-   │   @Mutate(v => v.toLowerCase())                        │
+   │   @Set(v => v.toLowerCase())                           │
    │   @Validate(v => isEmail(v))                           │
    │   declare email: string;                               │
    │ }                                                       │
@@ -766,11 +762,10 @@ Understanding how data flows through Dynamite helps you use it effectively. Here
    │ │   name: "User",                                  │   │
    │ │   columns: Map {                                 │   │
    │ │     "id" => {                                    │   │
-   │ │       primaryKey: true,                          │   │
-   │ │       default: () => uuid()                      │   │
+   │ │       primaryKey: true                           │   │
    │ │     },                                           │   │
    │ │     "email" => {                                 │   │
-   │ │       mutate: [v => v.toLowerCase()],            │   │
+   │ │       set: [v => v.toLowerCase()],               │   │
    │ │       validate: [v => isEmail(v)]                │   │
    │ │     }                                            │   │
    │ │   }                                              │   │
@@ -789,10 +784,10 @@ Understanding how data flows through Dynamite helps you use it effectively. Here
    ┌────────────────────────────────────────────────────────┐
    │ new User(data)                                         │
    │   ↓                                                    │
-   │ Apply @Default decorators                              │
-   │   id = uuid() → "550e8400-..."                         │
+   │ Apply @PrimaryKey autogeneration                       │
+   │   id = ulid() → "01ARZ3NDEK..."                        │
    │   ↓                                                    │
-   │ Apply @Mutate decorators                               │
+   │ Apply @Set decorators                                  │
    │   email = "john@example.com" (lowercased)              │
    │   ↓                                                    │
    │ Apply @Validate decorators                             │
@@ -809,7 +804,7 @@ Understanding how data flows through Dynamite helps you use it effectively. Here
    │   ↓                                                    │
    │ Extract attributes (exclude NonAttribute fields)       │
    │   {                                                    │
-   │     id: "550e8400-...",                                │
+   │     id: "01ARZ3NDEK...",                                │
    │     email: "john@example.com",                         │
    │     created_at: "2023-12-01T10:30:00.000Z",            │
    │     updated_at: "2023-12-01T10:30:00.000Z"             │
@@ -822,7 +817,7 @@ Understanding how data flows through Dynamite helps you use it effectively. Here
    │   ↓                                                    │
    │ marshall(data) → DynamoDB format                       │
    │   {                                                    │
-   │     id: { S: "550e8400-..." },                         │
+   │     id: { S: "01ARZ3NDEK..." },                         │
    │     email: { S: "john@example.com" },                  │
    │     created_at: { S: "2023-12-01T10:30:00.000Z" },     │
    │     updated_at: { S: "2023-12-01T10:30:00.000Z" }      │
@@ -880,8 +875,8 @@ RELATIONSHIP LOADING
 
 1. **Decorator Registration**: Happens once at class definition time
 2. **Default Values**: Applied in constructor before validation
-3. **Mutations**: Applied before validation, transforms data
-4. **Validation**: Runs after mutations, can throw errors
+3. **Setters**: `@Set` transforms applied before validation on write
+4. **Validation**: Runs after setters, can throw errors
 5. **Timestamps**: Auto-set on create/update operations
 6. **Serialization**: Excludes NonAttribute fields before persistence
 7. **Relationships**: Loaded lazily through separate queries

--- a/docs/references/decorators.de.md
+++ b/docs/references/decorators.de.md
@@ -8,11 +8,13 @@ Dieser Leitfaden bietet umfassende Dokumentation zu allen in Dynamite ORM verfü
 2. [@PrimaryKey - Primarschlussel](#primarykey-primarschlussel)
 3. [@Default - Standardwerte](#default-standardwerte)
 4. [@Validate - Validierungsfunktionen](#validate-validierungsfunktionen)
-5. [@Mutate - Datentransformation](#mutate-datentransformation)
-6. [@NotNull - Erforderliche Felder](#notnull-erforderliche-felder)
-7. [@CreatedAt - Erstellungs-Zeitstempel](#createdat-erstellungs-zeitstempel)
-8. [@UpdatedAt - Aktualisierungs-Zeitstempel](#updatedat-aktualisierungs-zeitstempel)
-9. [Best Practices](#best-practices)
+5. [@Set - Transformation beim Schreiben](#set-transformation-beim-schreiben)
+6. [@Get - Transformation beim Lesen](#get-transformation-beim-lesen)
+7. [@NotNull - Erforderliche Felder](#notnull-erforderliche-felder)
+8. [@CreatedAt - Erstellungs-Zeitstempel](#createdat-erstellungs-zeitstempel)
+9. [@UpdatedAt - Aktualisierungs-Zeitstempel](#updatedat-aktualisierungs-zeitstempel)
+10. [Lifecycle-Hook-Dekoratoren](#lifecycle-hook-dekoratoren)
+11. [Best Practices](#best-practices)
 
 ---
 
@@ -28,7 +30,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 class User extends Table<User> {
   // Primärschlüssel-Decorator
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Einfaches Feld ohne Decorators
@@ -49,7 +50,8 @@ class User extends Table<User> {
 
 **Daten-Decorators:**
 - `@Default()` - Setzt Standardwerte
-- `@Mutate()` - Transformiert Werte vor dem Speichern
+- `@Set()` - Transformiert Werte beim Schreiben
+- `@Get()` - Transformiert Werte beim Lesen
 - `@Validate()` - Validiert Werte vor dem Speichern
 - `@NotNull()` - Markiert Felder als erforderlich
 
@@ -68,7 +70,7 @@ class User extends Table<User> {
 
 ## @PrimaryKey - Primärschlüssel
 
-Der `@PrimaryKey`-Decorator definiert den Primärschlüssel der Tabelle. Intern wendet er automatisch `@Index` und `@IndexSort` an.
+Der `@PrimaryKey`-Decorator definiert den Primärschlüssel der Tabelle. Intern wendet er automatisch `@Index` und `@IndexSort` an. Er generiert und validiert außerdem automatisch eine ULID für das Feld; kombinieren Sie ihn daher nicht mit einem `@Default()`, das eine eigene ID erzeugt (z. B. ein UUID), da dies fehlschlägt.
 
 ### Syntax
 
@@ -79,11 +81,10 @@ Der `@PrimaryKey`-Decorator definiert den Primärschlüssel der Tabelle. Intern 
 ### Einfacher Primärschlüssel
 
 ```typescript
-import { Table, PrimaryKey, CreationOptional, Default } from "@arcaelas/dynamite";
+import { Table, PrimaryKey, CreationOptional } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -97,7 +98,7 @@ const user = await User.create({
   // id ist optional (CreationOptional) und wird automatisch generiert
 });
 
-console.log(user.id); // "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+console.log(user.id); // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 ```
 
 ---
@@ -117,7 +118,6 @@ Der `@Default`-Decorator setzt statische oder dynamische Standardwerte für Eige
 ```typescript
 class Settings extends Table<Settings> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default("dark")
@@ -146,7 +146,6 @@ console.log(settings.tags); // []
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default(() => new Date().toISOString())
@@ -239,15 +238,17 @@ class Password extends Table<Password> {
 
 ---
 
-## @Mutate - Datentransformation
+## @Set - Transformation beim Schreiben
 
-Der `@Mutate`-Decorator transformiert Werte, bevor sie in der Datenbank gespeichert werden.
+Der `@Set`-Decorator transformiert Werte, bevor sie in die Datenbank geschrieben werden.
 
 ### Syntax
 
 ```typescript
-@Mutate(transformer: (value: any) => any): PropertyDecorator
+@Set(transformer: (next: any, current: any) => any): PropertyDecorator
 ```
+
+Die Transformerfunktion erhält den neuen Wert (`next`) und den aktuellen Wert (`current`) der Eigenschaft.
 
 ### Grundlegende Transformationen
 
@@ -256,14 +257,14 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   declare email: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
+  @Set((v) => (v as string).trim())
+  @Set((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
   declare name: string;
 
-  @Mutate((v) => (v as string).replace(/\D/g, ""))
+  @Set((v) => (v as string).replace(/\D/g, ""))
   declare phone: string;
 }
 
@@ -282,6 +283,49 @@ console.log(user.phone); // "15551234567"
 
 ---
 
+## @Get - Transformation beim Lesen
+
+Der `@Get`-Decorator transformiert Werte, wenn sie aus der Datenbank gelesen werden. Er ist das Gegenstück zu `@Set` und eignet sich, um gespeicherte Rohwerte beim Zugriff in ein bequemeres Format zu überführen.
+
+### Syntax
+
+```typescript
+@Get(transformer: (value: any) => any): PropertyDecorator
+```
+
+### Grundlegende Transformationen
+
+```typescript
+class Event extends Table<Event> {
+  @PrimaryKey()
+  declare id: string;
+
+  // Beim Schreiben als ISO-String speichern, beim Lesen als Date zurückgeben
+  @Set((v) => (v as Date).toISOString())
+  @Get((v) => new Date(v as string))
+  declare starts_at: Date;
+
+  // Komma-getrennte Tags speichern, beim Lesen als Array zurückgeben
+  @Set((v) => (v as string[]).join(","))
+  @Get((v) => (v as string).split(","))
+  declare tags: string[];
+}
+
+// Verwendung
+const event = await Event.create({
+  id: "event-1",
+  starts_at: new Date("2025-01-15T10:30:00.000Z"),
+  tags: ["typescript", "dynamodb"]
+});
+
+console.log(event.starts_at instanceof Date); // true
+console.log(event.tags); // ["typescript", "dynamodb"]
+```
+
+> **Hinweis:** Ältere Schreib- und Serialisierungs-Decorators wurden durch `@Get` (Lesen) und `@Set` (Schreiben) ersetzt. Migrationsdetails finden Sie im [Migrationsleitfaden](./migration.de.md).
+
+---
+
 ## @NotNull - Erforderliche Felder
 
 Der `@NotNull`-Decorator markiert Felder als erforderlich und validiert, dass sie nicht null, undefined oder leere Strings sind.
@@ -297,7 +341,6 @@ Der `@NotNull`-Decorator markiert Felder als erforderlich und validiert, dass si
 ```typescript
 class Customer extends Table<Customer> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -348,7 +391,6 @@ Der `@CreatedAt`-Decorator setzt automatisch Datum und Uhrzeit der Erstellung im
 ```typescript
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -384,7 +426,6 @@ Der `@UpdatedAt`-Decorator aktualisiert automatisch Datum und Uhrzeit bei jedem 
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -416,6 +457,72 @@ console.log(doc.updated_at); // "2025-01-15T10:15:00Z" (aktualisiert)
 
 ---
 
+## Lifecycle-Hook-Dekoratoren
+
+Lifecycle-Hooks sind Methoden-Dekoratoren, die automatisch rund um die Persistenz-Operationen ausgeführt werden. Sie sind pro Operation opt-in und werden nur aktiviert, wenn die Operation mit `{ hook: true }` aufgerufen wird. Innerhalb eines Hooks verweist `this` auf die Entität, sodass deren Felder gelesen und mutiert werden können.
+
+### Verfügbare Hooks
+
+| Dekorator | Zeitpunkt | Argument |
+|-----------|-----------|----------|
+| `@BeforeCreate()` | vor dem Einfügen, kann `this` mutieren | kein Argument |
+| `@AfterCreate()` | nach dem Einfügen (`this` bereits persistiert) | kein Argument |
+| `@BeforeUpdate()` | vor dem Update | `changes` (Delta) |
+| `@AfterUpdate()` | nach dem Update | `changes` (Delta) |
+| `@BeforeDestroy()` | vor dem Löschen | kein Argument |
+| `@AfterDestroy()` | nach dem Löschen | kein Argument |
+
+### Grundlegende Verwendung
+
+```typescript
+import {
+  Table,
+  PrimaryKey,
+  CreationOptional,
+  BeforeCreate,
+  AfterCreate,
+  BeforeUpdate
+} from "@arcaelas/dynamite";
+
+class User extends Table<User> {
+  @PrimaryKey()
+  declare id: CreationOptional<string>;
+
+  declare email: string;
+  declare name: string;
+  declare slug: string;
+
+  @BeforeCreate()
+  normalize() {
+    // `this` ist die Entität und kann mutiert werden
+    this.email = this.email.toLowerCase().trim();
+    this.slug = this.name.toLowerCase().replace(/\s+/g, "-");
+  }
+
+  @AfterCreate()
+  async notify() {
+    // async-Hooks werden awaited
+    await sendWelcomeEmail(this.email);
+  }
+
+  @BeforeUpdate()
+  audit(changes: Partial<User>) {
+    // `changes` enthält das Delta der zu aktualisierenden Felder
+    console.log("Geänderte Felder:", Object.keys(changes));
+  }
+}
+```
+
+### Verhalten
+
+- Mehrere Hooks desselben Typs laufen in Deklarationsreihenfolge; async-Hooks werden awaited.
+- Aktivierung pro Operation: `User.create(data, { hook: true })`, `user.update(data, { hook: true })`, `user.destroy({ hook: true })`.
+- Bei Massen-`update`/`delete` laufen die Hooks einmal pro betroffener Entität.
+- Innerhalb einer Transaktion (`{ hook: true, tx }`) laufen `before*` beim Einreihen und `after*` nach dem Commit.
+- `increment()`/`decrement()` akzeptieren `{ tx }`, lösen aber keine Hooks aus.
+
+---
+
 ## Best Practices
 
 ### 1. CreationOptional richtig verwenden
@@ -442,12 +549,11 @@ class User extends Table<User> {
 class User extends Table<User> {
   // Empfohlene Reihenfolge: Schlüssel → Validierung → Transformation → Defaults → Zeitstempel
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
   @Validate((v) => /^[^\s@]+@/.test(v as string) || "Ungültig")
-  @Mutate((v) => (v as string).toLowerCase())
+  @Set((v) => (v as string).toLowerCase())
   @Name("email_address")
   declare email: string;
 }

--- a/docs/references/decorators.es.md
+++ b/docs/references/decorators.es.md
@@ -10,18 +10,19 @@ Esta guía proporciona documentación exhaustiva sobre todos los decoradores dis
 4. [@IndexSort - Configuracion de LSI](#indexsort-configuracion-de-lsi)
 5. [@Default - Valores por Defecto](#default-valores-por-defecto)
 6. [@Validate - Funciones de Validacion](#validate-funciones-de-validacion)
-7. [@Mutate - Transformacion de Datos](#mutate-transformacion-de-datos)
-8. [@Serialize - Transformacion Bidireccional](#serialize-transformacion-bidireccional)
+7. [@Set - Transformacion al Escribir](#set-transformacion-al-escribir)
+8. [@Get y @Set - Transformacion Bidireccional](#get-y-set-transformacion-bidireccional)
 9. [@NotNull - Campos Requeridos](#notnull-campos-requeridos)
 10. [@CreatedAt - Timestamp de Creacion](#createdat-timestamp-de-creacion)
 11. [@UpdatedAt - Timestamp de Actualizacion](#updatedat-timestamp-de-actualizacion)
 12. [@DeleteAt - Soft Delete](#deleteat-soft-delete)
-13. [@Name - Nombres Personalizados](#name-nombres-personalizados)
-14. [@HasMany - Relaciones Uno a Muchos](#hasmany-relaciones-uno-a-muchos)
-15. [@BelongsTo - Relaciones Muchos a Uno](#belongsto-relaciones-muchos-a-uno)
-16. [Combinando Multiples Decoradores](#combinando-multiples-decoradores)
-17. [Patrones de Decoradores Personalizados](#patrones-de-decoradores-personalizados)
-18. [Mejores Practicas](#mejores-practicas)
+13. [Decoradores de Hooks de ciclo de vida](#decoradores-de-hooks-de-ciclo-de-vida)
+14. [@Name - Nombres Personalizados](#name-nombres-personalizados)
+15. [@HasMany - Relaciones Uno a Muchos](#hasmany-relaciones-uno-a-muchos)
+16. [@BelongsTo - Relaciones Muchos a Uno](#belongsto-relaciones-muchos-a-uno)
+17. [Combinando Multiples Decoradores](#combinando-multiples-decoradores)
+18. [Patrones de Decoradores Personalizados](#patrones-de-decoradores-personalizados)
+19. [Mejores Practicas](#mejores-practicas)
 
 ---
 
@@ -37,7 +38,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 class User extends Table<User> {
   // Decorador de clave primaria
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Campo simple sin decoradores
@@ -58,8 +58,8 @@ class User extends Table<User> {
 
 **Decoradores de Datos:**
 - `@Default()` - Establece valores por defecto
-- `@Mutate()` - Transforma valores antes de guardar
-- `@Serialize()` - Transforma valores bidireccionalmente (DB ↔ App)
+- `@Set()` - Transforma valores al escribir (App → DB)
+- `@Get()` - Transforma valores al leer (DB → App)
 - `@Validate()` - Valida valores antes de guardar
 - `@NotNull()` - Marca campos como requeridos
 
@@ -67,6 +67,11 @@ class User extends Table<User> {
 - `@CreatedAt()` - Auto-timestamp en creación
 - `@UpdatedAt()` - Auto-timestamp en actualización
 - `@DeleteAt()` - Soft delete con timestamp
+
+**Decoradores de Hooks:**
+- `@BeforeCreate()` / `@AfterCreate()` - Antes/después de insertar
+- `@BeforeUpdate()` / `@AfterUpdate()` - Antes/después de actualizar
+- `@BeforeDestroy()` / `@AfterDestroy()` - Antes/después de eliminar
 
 **Decoradores de Relaciones:**
 - `@HasMany()` - Relación uno a muchos
@@ -94,7 +99,6 @@ import { Table, PrimaryKey, CreationOptional, Default } from "@arcaelas/dynamite
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -195,7 +199,6 @@ El decorador `@Index` marca una propiedad como **Partition Key** (clave de parti
 ```typescript
 class Customer extends Table<Customer> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Index()
@@ -214,7 +217,6 @@ const customers = await Customer.where({ email: "john@example.com" });
 ```typescript
 class Article extends Table<Article> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Index()
@@ -377,7 +379,6 @@ El decorador `@Default` establece valores por defecto estáticos o dinámicos pa
 ```typescript
 class Settings extends Table<Settings> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default("dark")
@@ -406,7 +407,6 @@ console.log(settings.tags); // []
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default(() => new Date().toISOString())
@@ -432,7 +432,6 @@ console.log(doc1.code !== doc2.code); // true
 ```typescript
 class UserProfile extends Table<UserProfile> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default(() => ({
@@ -466,7 +465,6 @@ import { CreationOptional } from "@arcaelas/dynamite";
 
 class Task extends Table<Task> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string; // Requerido
@@ -630,15 +628,17 @@ class DateRange extends Table<DateRange> {
 
 ---
 
-## @Mutate - Transformación de Datos
+## @Set - Transformación al Escribir
 
-El decorador `@Mutate` transforma valores antes de guardarlos en la base de datos.
+El decorador `@Set` transforma valores antes de guardarlos en la base de datos.
 
 ### Sintaxis
 
 ```typescript
-@Mutate(transformer: (value: any) => any): PropertyDecorator
+@Set(transformer: (next: any, current: any) => any): PropertyDecorator
 ```
+
+El transformador recibe el nuevo valor (`next`) y, opcionalmente, el valor actual (`current`). Los ejemplos que solo necesitan el nuevo valor pueden declarar un único parámetro.
 
 ### Transformaciones Básicas
 
@@ -647,14 +647,14 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   declare email: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
+  @Set((v) => (v as string).trim())
+  @Set((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
   declare name: string;
 
-  @Mutate((v) => (v as string).replace(/\D/g, ""))
+  @Set((v) => (v as string).replace(/\D/g, ""))
   declare phone: string;
 }
 
@@ -680,14 +680,14 @@ class Article extends Table<Article> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => (v as string).replace(/\s+/g, " "))
-  @Mutate((v) => (v as string).substring(0, 200))
+  @Set((v) => (v as string).trim())
+  @Set((v) => (v as string).replace(/\s+/g, " "))
+  @Set((v) => (v as string).substring(0, 200))
   declare title: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => (v as string).replace(/<[^>]*>/g, ""))
-  @Mutate((v) => (v as string).substring(0, 5000))
+  @Set((v) => (v as string).trim())
+  @Set((v) => (v as string).replace(/<[^>]*>/g, ""))
+  @Set((v) => (v as string).substring(0, 5000))
   declare content: string;
 }
 ```
@@ -699,13 +699,13 @@ class Financial extends Table<Financial> {
   @PrimaryKey()
   declare transaction_id: string;
 
-  @Mutate((v) => Math.round((v as number) * 100) / 100)
+  @Set((v) => Math.round((v as number) * 100) / 100)
   declare amount: number;
 
-  @Mutate((v) => Math.max(0, Math.min(100, v as number)))
+  @Set((v) => Math.max(0, Math.min(100, v as number)))
   declare percentage: number;
 
-  @Mutate((v) => Math.abs(v as number))
+  @Set((v) => Math.abs(v as number))
   declare quantity: number;
 }
 
@@ -729,7 +729,7 @@ class Settings extends Table<Settings> {
   @PrimaryKey()
   declare user_id: string;
 
-  @Mutate((v) => {
+  @Set((v) => {
     const config = v as Record<string, any>;
     return Object.keys(config).reduce((acc, key) => {
       acc[key.toLowerCase()] = config[key];
@@ -738,51 +738,48 @@ class Settings extends Table<Settings> {
   })
   declare preferences: Record<string, any>;
 
-  @Mutate((v) => Array.from(new Set(v as string[])))
+  @Set((v) => Array.from(new Set(v as string[])))
   declare tags: string[];
 }
 ```
 
 ---
 
-## @Serialize - Transformación Bidireccional
+## @Get y @Set - Transformación Bidireccional
 
-El decorador `@Serialize` permite transformar valores en ambas direcciones: al leer de la base de datos y al guardar. A diferencia de `@Mutate` (solo escritura), `@Serialize` maneja la conversión completa del ciclo de datos.
+Para transformar un valor en ambas direcciones se combinan `@Get` (al leer de la base de datos) y `@Set` (al guardar en la base de datos) sobre la misma propiedad, en líneas separadas. Juntos cubren la conversión completa del ciclo de datos.
 
 ### Sintaxis
 
 ```typescript
-@Serialize(fromDB: ((value: any) => any) | null, toDB?: ((value: any) => any) | null): PropertyDecorator
+@Get(transformer: (value: any) => any): PropertyDecorator      // DB → App (lectura)
+@Set(transformer: (next: any, current: any) => any): PropertyDecorator  // App → DB (escritura)
 ```
 
 ### Parámetros
 
-| Parámetro | Tipo | Descripción |
-|-----------|------|-------------|
-| `fromDB` | `Function \| null` | Transforma el valor al leer de la base de datos. Usa `null` para omitir. |
-| `toDB` | `Function \| null` | Transforma el valor al guardar en la base de datos. Usa `null` para omitir. |
+| Decorador | Dirección | Descripción |
+|-----------|-----------|-------------|
+| `@Get(fn)` | DB → App | Transforma el valor al leer de la base de datos. |
+| `@Set(fn)` | App → DB | Transforma el valor al guardar en la base de datos. |
 
 ### Transformación Bidireccional
 
 ```typescript
-import { Serialize } from "@arcaelas/dynamite";
+import { Get, Set } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
   // Boolean almacenado como número en DynamoDB
-  @Serialize(
-    (from) => from === 1,     // DB: 1 → App: true
-    (to) => to ? 1 : 0        // App: true → DB: 1
-  )
+  @Get((value) => value === 1)        // DB: 1 → App: true
+  @Set((value) => value ? 1 : 0)      // App: true → DB: 1
   declare active: boolean;
 
   // JSON almacenado como string
-  @Serialize(
-    (from) => JSON.parse(from),           // DB: '{"a":1}' → App: {a:1}
-    (to) => JSON.stringify(to)            // App: {a:1} → DB: '{"a":1}'
-  )
+  @Get((value) => JSON.parse(value))        // DB: '{"a":1}' → App: {a:1}
+  @Set((value) => JSON.stringify(value))    // App: {a:1} → DB: '{"a":1}'
   declare metadata: Record<string, any>;
 }
 
@@ -801,7 +798,7 @@ console.log(fetched.metadata); // { role: "admin" } (no string)
 
 ### Solo Transformar al Guardar
 
-Usa `null` como primer parámetro para omitir la transformación al leer:
+Usa únicamente `@Set` para transformar solo al escribir, sin transformar al leer:
 
 ```typescript
 class Product extends Table<Product> {
@@ -809,7 +806,7 @@ class Product extends Table<Product> {
   declare sku: string;
 
   // Solo normalizar al guardar, no transformar al leer
-  @Serialize(null, (to) => (to as string).toUpperCase().trim())
+  @Set((value) => (value as string).toUpperCase().trim())
   declare code: string;
 }
 
@@ -820,7 +817,7 @@ await Product.create({ sku: "prod-1", code: "  abc123  " });
 
 ### Solo Transformar al Leer
 
-Omite el segundo parámetro o usa `null` para solo transformar al leer:
+Usa únicamente `@Get` para transformar solo al leer:
 
 ```typescript
 class Settings extends Table<Settings> {
@@ -828,11 +825,11 @@ class Settings extends Table<Settings> {
   declare user_id: string;
 
   // Parse JSON solo al leer (se guarda como string directamente)
-  @Serialize((from) => JSON.parse(from))
+  @Get((value) => JSON.parse(value))
   declare preferences: Record<string, any>;
 
   // Convertir timestamp a Date solo al leer
-  @Serialize((from) => new Date(from), null)
+  @Get((value) => new Date(value))
   declare last_login: Date;
 }
 ```
@@ -866,10 +863,12 @@ class UserSecret extends Table<UserSecret> {
   @PrimaryKey()
   declare user_id: string;
 
-  @Serialize(decrypt, encrypt)
+  @Get(decrypt)
+  @Set(encrypt)
   declare api_key: string;
 
-  @Serialize(decrypt, encrypt)
+  @Get(decrypt)
+  @Set(encrypt)
   declare secret_token: string;
 }
 ```
@@ -883,10 +882,8 @@ class Document extends Table<Document> {
   @PrimaryKey()
   declare id: string;
 
-  @Serialize(
-    (from) => gunzipSync(Buffer.from(from, "base64")).toString(),
-    (to) => gzipSync(to).toString("base64")
-  )
+  @Get((value) => gunzipSync(Buffer.from(value, "base64")).toString())
+  @Set((value) => gzipSync(value).toString("base64"))
   declare content: string;
 }
 ```
@@ -899,27 +896,23 @@ class Analytics extends Table<Analytics> {
   declare event_id: string;
 
   // Set de DynamoDB a Array de JavaScript
-  @Serialize(
-    (from) => Array.from(from),           // Set → Array
-    (to) => new Set(to)                   // Array → Set
-  )
+  @Get((value) => Array.from(value))    // Set → Array
+  @Set((value) => new Set(value))       // Array → Set
   declare tags: string[];
 
   // BigInt para números grandes
-  @Serialize(
-    (from) => BigInt(from),
-    (to) => to.toString()
-  )
+  @Get((value) => BigInt(value))
+  @Set((value) => value.toString())
   declare large_number: bigint;
 }
 ```
 
-### Diferencias con @Mutate
+### @Set frente a @Get + @Set
 
-| Característica | @Mutate | @Serialize |
-|----------------|---------|------------|
+| Característica | Solo `@Set` | `@Get` + `@Set` |
+|----------------|-------------|-----------------|
 | Dirección | Solo al guardar | Bidireccional |
-| Parámetros | Una función | Dos funciones (fromDB, toDB) |
+| Decoradores | Uno (`@Set`) | Dos (`@Get` y `@Set`) |
 | Caso de uso | Normalización | Conversión de tipos |
 
 ```typescript
@@ -927,15 +920,13 @@ class Example extends Table<Example> {
   @PrimaryKey()
   declare id: string;
 
-  // @Mutate: Solo normaliza al guardar
-  @Mutate((v) => (v as string).toLowerCase())
+  // Solo @Set: normaliza al guardar
+  @Set((v) => (v as string).toLowerCase())
   declare email: string;  // "JOHN@EXAMPLE.COM" → "john@example.com" (solo escritura)
 
-  // @Serialize: Transforma en ambas direcciones
-  @Serialize(
-    (from) => from === 1,
-    (to) => to ? 1 : 0
-  )
+  // @Get + @Set: transforma en ambas direcciones
+  @Get((value) => value === 1)
+  @Set((value) => value ? 1 : 0)
   declare active: boolean;  // true ↔ 1 (lectura y escritura)
 }
 ```
@@ -957,7 +948,6 @@ El decorador `@NotNull` marca campos como requeridos, validando que no sean nulo
 ```typescript
 class Customer extends Table<Customer> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -999,7 +989,7 @@ class Registration extends Table<Registration> {
   declare id: string;
 
   @NotNull()
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   @Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Email inválido")
   declare email: string;
 
@@ -1049,7 +1039,6 @@ El decorador `@CreatedAt` establece automáticamente la fecha y hora de creació
 ```typescript
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1073,7 +1062,6 @@ console.log(post.created_at); // "2025-01-15T10:30:00.123Z"
 ```typescript
 class AuditLog extends Table<AuditLog> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -1139,7 +1127,6 @@ El decorador `@UpdatedAt` actualiza automáticamente la fecha y hora cada vez qu
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1174,7 +1161,6 @@ console.log(doc.updated_at); // "2025-01-15T10:15:00Z" (actualizado)
 ```typescript
 class Article extends Table<Article> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1253,7 +1239,6 @@ import { DeleteAt } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -1345,7 +1330,6 @@ if (deleted_doc[0]) {
 ```typescript
 class File extends Table<File> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -1397,7 +1381,6 @@ async function listTrash(owner_id: string): Promise<File[]> {
 ```typescript
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1447,11 +1430,11 @@ await dynamite.tx(async (tx) => {
 
   // Soft delete de todas las órdenes
   for (const order of orders) {
-    await order.destroy(tx);
+    await order.destroy({ tx });
   }
 
   // Soft delete del usuario
-  await user.destroy(tx);
+  await user.destroy({ tx });
 });
 ```
 
@@ -1463,6 +1446,73 @@ Al aplicar `@DeleteAt`:
 2. **softDelete = true**: Activa el comportamiento de soft delete en `destroy()`
 3. **Filtrado automático**: `where()` excluye registros con `deleted_at` establecido
 4. **Métodos adicionales**: Habilita `withTrashed()` y `onlyTrashed()`
+
+---
+
+## Decoradores de Hooks de ciclo de vida
+
+Decoradores de método que se ejecutan automáticamente alrededor de las operaciones de persistencia. Son opt-in: solo corren cuando la operación recibe `{ hook: true }`. Dentro del hook, `this` es la entidad.
+
+| Decorador | Cuándo se ejecuta | Argumento |
+|-----------|-------------------|-----------|
+| `@BeforeCreate()` | Antes de insertar. Puede mutar `this`. | — |
+| `@AfterCreate()` | Después de insertar (`this` ya persistido). | — |
+| `@BeforeUpdate()` | Antes de actualizar. | `changes` (delta) |
+| `@AfterUpdate()` | Después de actualizar. | `changes` (delta) |
+| `@BeforeDestroy()` | Antes de eliminar. | — |
+| `@AfterDestroy()` | Después de eliminar. | — |
+
+### Uso Básico
+
+```typescript
+import {
+  Table,
+  PrimaryKey,
+  BeforeCreate,
+  AfterCreate,
+  BeforeUpdate,
+  CreationOptional
+} from "@arcaelas/dynamite";
+
+class User extends Table<User> {
+  @PrimaryKey()
+  declare id: CreationOptional<string>;
+
+  declare name: string;
+  declare email: string;
+  declare slug: string;
+
+  @BeforeCreate()
+  normalizeOnCreate() {
+    // `this` es la entidad; puede mutarse antes de persistir
+    this.email = this.email.toLowerCase().trim();
+    this.slug = this.name.toLowerCase().replace(/\s+/g, "-");
+  }
+
+  @AfterCreate()
+  async notifyCreated() {
+    // Los hooks async se esperan con await
+    await fetch("/internal/welcome", {
+      method: "POST",
+      body: JSON.stringify({ email: this.email })
+    });
+  }
+
+  @BeforeUpdate()
+  trackChanges(changes: Partial<User>) {
+    // `changes` es el delta de campos modificados
+    console.log("Campos a actualizar:", Object.keys(changes));
+  }
+}
+```
+
+### Comportamiento
+
+- Se pueden declarar varios hooks del mismo tipo; corren en orden de declaración y los async se esperan con await.
+- Activación por operación: `User.create(data, { hook: true })`, `user.update(data, { hook: true })`, `user.destroy({ hook: true })`.
+- En `update`/`delete` masivos, los hooks corren una vez por entidad afectada.
+- Dentro de una transacción (`{ hook: true, tx }`), los `before*` corren al encolar y los `after*` tras el commit.
+- `increment()`/`decrement()` aceptan `{ tx }` pero no disparan hooks.
 
 ---
 
@@ -1565,7 +1615,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -1736,8 +1785,8 @@ import {
   IndexSort,
   Default,
   Validate,
-  Mutate,
-  Serialize,
+  Get,
+  Set,
   NotNull,
   CreatedAt,
   UpdatedAt,
@@ -1752,17 +1801,16 @@ import {
 @Name("users")
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   @Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Email inválido")
   @Name("email_address")
   declare email: string;
 
   @NotNull()
-  @Mutate((v) => (v as string).trim())
+  @Set((v) => (v as string).trim())
   @Validate([
     (v) => (v as string).length >= 2 || "Nombre muy corto",
     (v) => (v as string).length <= 50 || "Nombre muy largo"
@@ -1778,16 +1826,12 @@ class User extends Table<User> {
   declare role: CreationOptional<string>;
 
   @Default(() => true)
-  @Serialize(
-    (from) => from === 1,
-    (to) => to ? 1 : 0
-  )
+  @Get((value) => value === 1)
+  @Set((value) => value ? 1 : 0)
   declare active: CreationOptional<boolean>;
 
-  @Serialize(
-    (from) => JSON.parse(from),
-    (to) => JSON.stringify(to)
-  )
+  @Get((value) => JSON.parse(value))
+  @Set((value) => JSON.stringify(value))
   declare preferences: CreationOptional<Record<string, any>>;
 
   @CreatedAt()
@@ -1947,7 +1991,7 @@ class Product extends Table<Product> {
 ```typescript
 import { decorator } from "@arcaelas/dynamite";
 
-// Transformación bidireccional (similar a @Serialize pero personalizado)
+// Transformación bidireccional (equivalente a combinar @Get y @Set, pero personalizado)
 export const JsonColumn = decorator((col) => {
   // Al guardar: objeto → JSON string
   col.set((current, next) => {
@@ -2108,16 +2152,16 @@ Combina múltiples decoradores existentes en uno:
 function EmailField(): PropertyDecorator {
   return (target: any, prop: string | symbol) => {
     NotNull()(target, prop);
-    Mutate((v) => (v as string).toLowerCase().trim())(target, prop);
+    Set((v) => (v as string).toLowerCase().trim())(target, prop);
     Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Email inválido")(target, prop);
   };
 }
 
 function SlugField(): PropertyDecorator {
   return (target: any, prop: string | symbol) => {
-    Mutate((v) => (v as string).toLowerCase())(target, prop);
-    Mutate((v) => (v as string).replace(/[^a-z0-9]+/g, "-"))(target, prop);
-    Mutate((v) => (v as string).replace(/^-+|-+$/g, ""))(target, prop);
+    Set((v) => (v as string).toLowerCase())(target, prop);
+    Set((v) => (v as string).replace(/[^a-z0-9]+/g, "-"))(target, prop);
+    Set((v) => (v as string).replace(/^-+|-+$/g, ""))(target, prop);
     Validate((v) => (v as string).length > 0 || "Slug no puede estar vacío")(target, prop);
   };
 }
@@ -2211,12 +2255,11 @@ class User extends Table<User> {
 class User extends Table<User> {
   // Orden recomendado: Clave → Validación → Transformación → Defaults → Timestamps
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
   @Validate((v) => /^[^\s@]+@/.test(v as string) || "Inválido")
-  @Mutate((v) => (v as string).toLowerCase())
+  @Set((v) => (v as string).toLowerCase())
   @Name("email_address")
   declare email: string;
 }

--- a/docs/references/decorators.md
+++ b/docs/references/decorators.md
@@ -10,8 +10,8 @@ This guide provides comprehensive documentation for all decorators available in 
 4. [@IndexSort - LSI Configuration](#indexsort-lsi-configuration)
 5. [@Default - Default Values](#default-default-values)
 6. [@Validate - Validation Functions](#validate-validation-functions)
-7. [@Mutate - Data Transformation](#mutate-data-transformation)
-8. [@Serialize - Bidirectional Transformation](#serialize-bidirectional-transformation)
+7. [@Set - Write Transformation](#set-write-transformation)
+8. [@Get and @Set - Bidirectional Transformation](#get-and-set-bidirectional-transformation)
 9. [@NotNull - Required Fields](#notnull-required-fields)
 10. [@CreatedAt - Creation Timestamp](#createdat-creation-timestamp)
 11. [@UpdatedAt - Update Timestamp](#updatedat-update-timestamp)
@@ -21,9 +21,10 @@ This guide provides comprehensive documentation for all decorators available in 
 15. [@HasOne - One to One Relationships](#hasone-one-to-one-relationships)
 16. [@BelongsTo - Many to One Relationships](#belongsto-many-to-one-relationships)
 17. [@ManyToMany - Many to Many Relationships](#manytomany-many-to-many-relationships)
-18. [Combining Multiple Decorators](#combining-multiple-decorators)
-19. [Custom Decorator Patterns](#custom-decorator-patterns)
-20. [Best Practices](#best-practices)
+18. [Lifecycle Hook Decorators](#lifecycle-hook-decorators)
+19. [Combining Multiple Decorators](#combining-multiple-decorators)
+20. [Custom Decorator Patterns](#custom-decorator-patterns)
+21. [Best Practices](#best-practices)
 
 ---
 
@@ -39,7 +40,6 @@ import { Table, PrimaryKey, Default, CreationOptional } from "@arcaelas/dynamite
 class User extends Table<User> {
   // Primary key decorator
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Simple field without decorators
@@ -60,8 +60,8 @@ class User extends Table<User> {
 
 **Data Decorators:**
 - `@Default()` - Sets default values
-- `@Mutate()` - Transforms values before saving
-- `@Serialize()` - Transforms values bidirectionally (DB <-> App)
+- `@Set()` - Transforms values when writing (before saving)
+- `@Get()` - Transforms values when reading (from the database)
 - `@Validate()` - Validates values before saving
 - `@NotNull()` - Marks fields as required
 
@@ -98,7 +98,6 @@ import { Table, PrimaryKey, CreationOptional, Default } from "@arcaelas/dynamite
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -112,7 +111,7 @@ const user = await User.create({
   // id is optional (CreationOptional) and auto-generated
 });
 
-console.log(user.id); // "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+console.log(user.id); // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 ```
 
 ### Primary Key with Static Value
@@ -199,7 +198,6 @@ The `@Index` decorator marks a property as **Partition Key**. It is fundamental 
 ```typescript
 class Customer extends Table<Customer> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Index()
@@ -218,7 +216,6 @@ const customers = await Customer.where({ email: "john@example.com" });
 ```typescript
 class Article extends Table<Article> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Index()
@@ -381,7 +378,6 @@ The `@Default` decorator sets static or dynamic default values for properties.
 ```typescript
 class Settings extends Table<Settings> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default("dark")
@@ -410,7 +406,6 @@ console.log(settings.tags); // []
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default(() => new Date().toISOString())
@@ -436,7 +431,6 @@ console.log(doc1.code !== doc2.code); // true
 ```typescript
 class UserProfile extends Table<UserProfile> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @Default(() => ({
@@ -470,7 +464,6 @@ import { CreationOptional } from "@arcaelas/dynamite";
 
 class Task extends Table<Task> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string; // Required
@@ -634,15 +627,17 @@ class DateRange extends Table<DateRange> {
 
 ---
 
-## @Mutate - Data Transformation
+## @Set - Write Transformation
 
-The `@Mutate` decorator transforms values before saving them to the database.
+The `@Set` decorator transforms values when writing them, before they are saved to the database.
 
 ### Syntax
 
 ```typescript
-@Mutate(transformer: (value: any) => any): PropertyDecorator
+@Set(transformer: (next: any, current: any) => any): PropertyDecorator
 ```
+
+The transformer receives the incoming value (`next`) and the current stored value (`current`). Most transformations only need `next`.
 
 ### Basic Transformations
 
@@ -651,14 +646,14 @@ class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   declare email: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
+  @Set((v) => (v as string).trim())
+  @Set((v) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase())
   declare name: string;
 
-  @Mutate((v) => (v as string).replace(/\D/g, ""))
+  @Set((v) => (v as string).replace(/\D/g, ""))
   declare phone: string;
 }
 
@@ -684,14 +679,14 @@ class Article extends Table<Article> {
   @PrimaryKey()
   declare id: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => (v as string).replace(/\s+/g, " "))
-  @Mutate((v) => (v as string).substring(0, 200))
+  @Set((v) => (v as string).trim())
+  @Set((v) => (v as string).replace(/\s+/g, " "))
+  @Set((v) => (v as string).substring(0, 200))
   declare title: string;
 
-  @Mutate((v) => (v as string).trim())
-  @Mutate((v) => (v as string).replace(/<[^>]*>/g, ""))
-  @Mutate((v) => (v as string).substring(0, 5000))
+  @Set((v) => (v as string).trim())
+  @Set((v) => (v as string).replace(/<[^>]*>/g, ""))
+  @Set((v) => (v as string).substring(0, 5000))
   declare content: string;
 }
 ```
@@ -703,13 +698,13 @@ class Financial extends Table<Financial> {
   @PrimaryKey()
   declare transaction_id: string;
 
-  @Mutate((v) => Math.round((v as number) * 100) / 100)
+  @Set((v) => Math.round((v as number) * 100) / 100)
   declare amount: number;
 
-  @Mutate((v) => Math.max(0, Math.min(100, v as number)))
+  @Set((v) => Math.max(0, Math.min(100, v as number)))
   declare percentage: number;
 
-  @Mutate((v) => Math.abs(v as number))
+  @Set((v) => Math.abs(v as number))
   declare quantity: number;
 }
 
@@ -733,7 +728,7 @@ class Settings extends Table<Settings> {
   @PrimaryKey()
   declare user_id: string;
 
-  @Mutate((v) => {
+  @Set((v) => {
     const config = v as Record<string, any>;
     return Object.keys(config).reduce((acc, key) => {
       acc[key.toLowerCase()] = config[key];
@@ -742,51 +737,48 @@ class Settings extends Table<Settings> {
   })
   declare preferences: Record<string, any>;
 
-  @Mutate((v) => Array.from(new Set(v as string[])))
+  @Set((v) => Array.from(new Set(v as string[])))
   declare tags: string[];
 }
 ```
 
 ---
 
-## @Serialize - Bidirectional Transformation
+## @Get and @Set - Bidirectional Transformation
 
-The `@Serialize` decorator allows transforming values in both directions: when reading from the database and when saving. Unlike `@Mutate` (write-only), `@Serialize` handles the complete data cycle conversion.
+Pairing `@Get` and `@Set` on the same property transforms values in both directions: `@Get` runs when reading from the database and `@Set` runs when saving. Unlike a lone `@Set` (write-only), combining both decorators handles the complete data cycle conversion.
 
 ### Syntax
 
 ```typescript
-@Serialize(fromDB: ((value: any) => any) | null, toDB?: ((value: any) => any) | null): PropertyDecorator
+@Get(fromDB: (value: any) => any): PropertyDecorator
+@Set(toDB: (next: any, current: any) => any): PropertyDecorator
 ```
 
 ### Parameters
 
-| Parameter | Type | Description |
+| Decorator | Type | Description |
 |-----------|------|-------------|
-| `fromDB` | `Function \| null` | Transforms the value when reading from database. Use `null` to skip. |
-| `toDB` | `Function \| null` | Transforms the value when saving to database. Use `null` to skip. |
+| `@Get` | `(value) => any` | Transforms the value when reading from the database. Omit to skip. |
+| `@Set` | `(next, current) => any` | Transforms the value when saving to the database. Omit to skip. |
 
 ### Bidirectional Transformation
 
 ```typescript
-import { Serialize } from "@arcaelas/dynamite";
+import { Get, Set } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
   declare id: string;
 
   // Boolean stored as number in DynamoDB
-  @Serialize(
-    (from) => from === 1,     // DB: 1 -> App: true
-    (to) => to ? 1 : 0        // App: true -> DB: 1
-  )
+  @Get((from) => from === 1)     // DB: 1 -> App: true
+  @Set((to) => to ? 1 : 0)       // App: true -> DB: 1
   declare active: boolean;
 
   // JSON stored as string
-  @Serialize(
-    (from) => JSON.parse(from),           // DB: '{"a":1}' -> App: {a:1}
-    (to) => JSON.stringify(to)            // App: {a:1} -> DB: '{"a":1}'
-  )
+  @Get((from) => JSON.parse(from))           // DB: '{"a":1}' -> App: {a:1}
+  @Set((to) => JSON.stringify(to))           // App: {a:1} -> DB: '{"a":1}'
   declare metadata: Record<string, any>;
 }
 
@@ -805,7 +797,7 @@ console.log(fetched.metadata); // { role: "admin" } (not string)
 
 ### Transform Only on Save
 
-Use `null` as the first parameter to skip transformation when reading:
+Use a lone `@Set` to skip transformation when reading:
 
 ```typescript
 class Product extends Table<Product> {
@@ -813,7 +805,7 @@ class Product extends Table<Product> {
   declare sku: string;
 
   // Only normalize when saving, no transformation when reading
-  @Serialize(null, (to) => (to as string).toUpperCase().trim())
+  @Set((to) => (to as string).toUpperCase().trim())
   declare code: string;
 }
 
@@ -824,7 +816,7 @@ await Product.create({ sku: "prod-1", code: "  abc123  " });
 
 ### Transform Only on Read
 
-Omit the second parameter or use `null` to only transform when reading:
+Use a lone `@Get` to only transform when reading:
 
 ```typescript
 class Settings extends Table<Settings> {
@@ -832,11 +824,11 @@ class Settings extends Table<Settings> {
   declare user_id: string;
 
   // Parse JSON only when reading (saved as string directly)
-  @Serialize((from) => JSON.parse(from))
+  @Get((from) => JSON.parse(from))
   declare preferences: Record<string, any>;
 
   // Convert timestamp to Date only when reading
-  @Serialize((from) => new Date(from), null)
+  @Get((from) => new Date(from))
   declare last_login: Date;
 }
 ```
@@ -870,10 +862,12 @@ class UserSecret extends Table<UserSecret> {
   @PrimaryKey()
   declare user_id: string;
 
-  @Serialize(decrypt, encrypt)
+  @Get(decrypt)
+  @Set(encrypt)
   declare api_key: string;
 
-  @Serialize(decrypt, encrypt)
+  @Get(decrypt)
+  @Set(encrypt)
   declare secret_token: string;
 }
 ```
@@ -887,10 +881,8 @@ class Document extends Table<Document> {
   @PrimaryKey()
   declare id: string;
 
-  @Serialize(
-    (from) => gunzipSync(Buffer.from(from, "base64")).toString(),
-    (to) => gzipSync(to).toString("base64")
-  )
+  @Get((from) => gunzipSync(Buffer.from(from, "base64")).toString())
+  @Set((to) => gzipSync(to).toString("base64"))
   declare content: string;
 }
 ```
@@ -903,27 +895,23 @@ class Analytics extends Table<Analytics> {
   declare event_id: string;
 
   // DynamoDB Set to JavaScript Array
-  @Serialize(
-    (from) => Array.from(from),           // Set -> Array
-    (to) => new Set(to)                   // Array -> Set
-  )
+  @Get((from) => Array.from(from))           // Set -> Array
+  @Set((to) => new Set(to))                  // Array -> Set
   declare tags: string[];
 
   // BigInt for large numbers
-  @Serialize(
-    (from) => BigInt(from),
-    (to) => to.toString()
-  )
+  @Get((from) => BigInt(from))
+  @Set((to) => to.toString())
   declare large_number: bigint;
 }
 ```
 
-### Differences from @Mutate
+### @Set only vs @Get + @Set
 
-| Feature | @Mutate | @Serialize |
-|---------|---------|------------|
+| Feature | `@Set` only | `@Get` + `@Set` |
+|---------|-------------|-----------------|
 | Direction | Save only | Bidirectional |
-| Parameters | One function | Two functions (fromDB, toDB) |
+| Decorators | One decorator | Two decorators (`@Get`, `@Set`) |
 | Use case | Normalization | Type conversion |
 
 ```typescript
@@ -931,15 +919,13 @@ class Example extends Table<Example> {
   @PrimaryKey()
   declare id: string;
 
-  // @Mutate: Only normalizes when saving
-  @Mutate((v) => (v as string).toLowerCase())
+  // @Set only: Normalizes when saving
+  @Set((v) => (v as string).toLowerCase())
   declare email: string;  // "JOHN@EXAMPLE.COM" -> "john@example.com" (write only)
 
-  // @Serialize: Transforms in both directions
-  @Serialize(
-    (from) => from === 1,
-    (to) => to ? 1 : 0
-  )
+  // @Get + @Set: Transforms in both directions
+  @Get((from) => from === 1)
+  @Set((to) => to ? 1 : 0)
   declare active: boolean;  // true <-> 1 (read and write)
 }
 ```
@@ -961,7 +947,6 @@ The `@NotNull` decorator marks fields as required, validating that they are not 
 ```typescript
 class Customer extends Table<Customer> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -1003,7 +988,7 @@ class Registration extends Table<Registration> {
   declare id: string;
 
   @NotNull()
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   @Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Invalid email")
   declare email: string;
 
@@ -1053,7 +1038,6 @@ The `@CreatedAt` decorator automatically sets the creation date and time in ISO 
 ```typescript
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1077,7 +1061,6 @@ console.log(post.created_at); // "2025-01-15T10:30:00.123Z"
 ```typescript
 class AuditLog extends Table<AuditLog> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare user_id: string;
@@ -1143,7 +1126,6 @@ The `@UpdatedAt` decorator automatically updates the date and time each time the
 ```typescript
 class Document extends Table<Document> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1178,7 +1160,6 @@ console.log(doc.updated_at); // "2025-01-15T10:15:00Z" (updated)
 ```typescript
 class Article extends Table<Article> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1257,7 +1238,6 @@ import { DeleteAt } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -1349,7 +1329,6 @@ if (deleted_doc[0]) {
 ```typescript
 class File extends Table<File> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare name: string;
@@ -1401,7 +1380,6 @@ async function list_trash(owner_id: string): Promise<File[]> {
 ```typescript
 class Post extends Table<Post> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   declare title: string;
@@ -1451,11 +1429,11 @@ await dynamite.tx(async (tx) => {
 
   // Soft delete all orders
   for (const order of orders) {
-    await order.destroy(tx);
+    await order.destroy({ tx });
   }
 
   // Soft delete user
-  await user.destroy(tx);
+  await user.destroy({ tx });
 });
 ```
 
@@ -1577,7 +1555,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -1696,7 +1673,6 @@ class User extends Table<User> {
 
 class Profile extends Table<Profile> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -1982,6 +1958,79 @@ console.log(student?.courses); // Course[]
 
 ---
 
+## Lifecycle Hook Decorators
+
+Method decorators that run automatically around persistence operations. They are opt-in: they only run when the operation receives `{ hook: true }`. Inside a hook, `this` is the entity instance.
+
+| Decorator | Runs | Argument |
+|-----------|------|----------|
+| `@BeforeCreate()` | Before insert. May mutate `this`. | — |
+| `@AfterCreate()` | After insert (`this` already persisted). | — |
+| `@BeforeUpdate()` | Before update. | `changes` (delta) |
+| `@AfterUpdate()` | After update. | `changes` (delta) |
+| `@BeforeDestroy()` | Before delete. | — |
+| `@AfterDestroy()` | After delete. | — |
+
+### Example
+
+```typescript
+import {
+  Table,
+  PrimaryKey,
+  CreationOptional,
+  BeforeCreate,
+  AfterCreate,
+  BeforeUpdate
+} from "@arcaelas/dynamite";
+
+class User extends Table<User> {
+  @PrimaryKey()
+  declare id: CreationOptional<string>;
+
+  declare name: string;
+  declare email: string;
+  declare slug: string;
+
+  @BeforeCreate()
+  normalize() {
+    // `this` is the entity; mutations are persisted
+    this.email = this.email.toLowerCase().trim();
+    this.slug = this.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  }
+
+  @AfterCreate()
+  async notify() {
+    // Runs after the record has been persisted
+    await sendWelcomeEmail(this.email);
+  }
+
+  @BeforeUpdate()
+  syncEmail(changes: Partial<User>) {
+    // `changes` holds the delta about to be written
+    if (changes.email) {
+      this.email = changes.email.toLowerCase().trim();
+    }
+  }
+}
+
+// Hooks only run when explicitly enabled
+const user = await User.create(
+  { name: "John Doe", email: "  JOHN@EXAMPLE.COM  " },
+  { hook: true }
+);
+
+console.log(user.email); // "john@example.com"
+console.log(user.slug);  // "john-doe"
+```
+
+- Multiple hooks of the same type run in declaration order; async hooks are awaited.
+- Activate per operation: `User.create(data, { hook: true })`, `user.update(data, { hook: true })`, `user.destroy({ hook: true })`.
+- In mass `update`/`delete`, hooks run once per affected entity.
+- Inside a transaction (`{ hook: true, tx }`), `before*` run when queued and `after*` after commit.
+- `increment()`/`decrement()` accept `{ tx }` but do not trigger hooks.
+
+---
+
 ## Combining Multiple Decorators
 
 ### Complete Model with All Decorators
@@ -1994,8 +2043,8 @@ import {
   IndexSort,
   Default,
   Validate,
-  Mutate,
-  Serialize,
+  Get,
+  Set,
   NotNull,
   CreatedAt,
   UpdatedAt,
@@ -2012,17 +2061,16 @@ import {
 @Name("users")
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
-  @Mutate((v) => (v as string).toLowerCase().trim())
+  @Set((v) => (v as string).toLowerCase().trim())
   @Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Invalid email")
   @Name("email_address")
   declare email: string;
 
   @NotNull()
-  @Mutate((v) => (v as string).trim())
+  @Set((v) => (v as string).trim())
   @Validate([
     (v) => (v as string).length >= 2 || "Name too short",
     (v) => (v as string).length <= 50 || "Name too long"
@@ -2038,16 +2086,12 @@ class User extends Table<User> {
   declare role: CreationOptional<string>;
 
   @Default(() => true)
-  @Serialize(
-    (from) => from === 1,
-    (to) => to ? 1 : 0
-  )
+  @Get((from) => from === 1)
+  @Set((to) => to ? 1 : 0)
   declare active: CreationOptional<boolean>;
 
-  @Serialize(
-    (from) => JSON.parse(from),
-    (to) => JSON.stringify(to)
-  )
+  @Get((from) => JSON.parse(from))
+  @Set((to) => JSON.stringify(to))
   declare preferences: CreationOptional<Record<string, any>>;
 
   @CreatedAt()
@@ -2213,7 +2257,7 @@ class Product extends Table<Product> {
 ```typescript
 import { decorator } from "@arcaelas/dynamite";
 
-// Bidirectional transformation (similar to @Serialize but customized)
+// Bidirectional transformation (similar to @Get + @Set but customized)
 export const JsonColumn = decorator((col) => {
   // On save: object -> JSON string
   col.set((current, next) => {
@@ -2374,16 +2418,16 @@ Combine multiple existing decorators into one:
 function EmailField(): PropertyDecorator {
   return (target: any, prop: string | symbol) => {
     NotNull()(target, prop);
-    Mutate((v) => (v as string).toLowerCase().trim())(target, prop);
+    Set((v) => (v as string).toLowerCase().trim())(target, prop);
     Validate((v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v as string) || "Invalid email")(target, prop);
   };
 }
 
 function SlugField(): PropertyDecorator {
   return (target: any, prop: string | symbol) => {
-    Mutate((v) => (v as string).toLowerCase())(target, prop);
-    Mutate((v) => (v as string).replace(/[^a-z0-9]+/g, "-"))(target, prop);
-    Mutate((v) => (v as string).replace(/^-+|-+$/g, ""))(target, prop);
+    Set((v) => (v as string).toLowerCase())(target, prop);
+    Set((v) => (v as string).replace(/[^a-z0-9]+/g, "-"))(target, prop);
+    Set((v) => (v as string).replace(/^-+|-+$/g, ""))(target, prop);
     Validate((v) => (v as string).length > 0 || "Slug cannot be empty")(target, prop);
   };
 }
@@ -2477,12 +2521,11 @@ class User extends Table<User> {
 class User extends Table<User> {
   // Recommended order: Key -> Validation -> Transformation -> Defaults -> Timestamps
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
   @Validate((v) => /^[^\s@]+@/.test(v as string) || "Invalid")
-  @Mutate((v) => (v as string).toLowerCase())
+  @Set((v) => (v as string).toLowerCase())
   @Name("email_address")
   declare email: string;
 }

--- a/docs/references/migration.de.md
+++ b/docs/references/migration.de.md
@@ -67,13 +67,12 @@ const users = await User.findAll({
 ```typescript
 // Dynamite (DynamoDB)
 import {
-  Table, PrimaryKey, Default, NotNull, CreatedAt,
+  Table, PrimaryKey, NotNull, CreatedAt,
   HasMany, BelongsTo, CreationOptional, NonAttribute
 } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>; // UUID statt Auto-Increment verwenden
 
   @NotNull()
@@ -90,7 +89,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -217,13 +215,12 @@ const users = await userRepository.find({
 ```typescript
 // Dynamite
 import {
-  Table, PrimaryKey, Default, NotNull, CreatedAt, UpdatedAt,
+  Table, PrimaryKey, NotNull, CreatedAt, UpdatedAt,
   HasMany, BelongsTo, CreationOptional, NonAttribute
 } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -243,7 +240,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -338,13 +334,12 @@ const users = await User.find({
 ```typescript
 // Dynamite
 import {
-  Table, PrimaryKey, Default, NotNull, CreatedAt,
+  Table, PrimaryKey, NotNull, CreatedAt,
   CreationOptional
 } from "@arcaelas/dynamite";
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>; // MongoDB _id → DynamoDB id
 
   @NotNull()
@@ -419,7 +414,6 @@ const user = await User.create({ name: "John" });
 // Alle Konfiguration über Decorators
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()

--- a/docs/references/migration.es.md
+++ b/docs/references/migration.es.md
@@ -73,7 +73,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>; // Usar UUID en lugar de auto-increment
 
   @NotNull()
@@ -90,7 +89,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -223,7 +221,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -243,7 +240,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -344,7 +340,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>; // MongoDB _id → DynamoDB id
 
   @NotNull()
@@ -419,7 +414,6 @@ const user = await User.create({ name: "John" });
 // Toda la configuración via decoradores
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()

--- a/docs/references/migration.md
+++ b/docs/references/migration.md
@@ -73,8 +73,7 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
-  declare id: CreationOptional<string>; // Use UUID instead of auto-increment
+  declare id: CreationOptional<string>; // Auto-generated ULID instead of auto-increment
 
   @NotNull()
   declare email: string;
@@ -90,7 +89,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -223,7 +221,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -243,7 +240,6 @@ class User extends Table<User> {
 
 class Order extends Table<Order> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()
@@ -344,7 +340,6 @@ import {
 
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>; // MongoDB _id → DynamoDB id
 
   @NotNull()
@@ -419,7 +414,6 @@ const user = await User.create({ name: "John" });
 // All configuration via decorators
 class User extends Table<User> {
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   @NotNull()

--- a/docs/references/table.de.md
+++ b/docs/references/table.de.md
@@ -82,9 +82,23 @@ await user.save();
 
 ## Instanzmethoden
 
-### `save(): Promise<boolean>`
+> **Mutations-Optionen:** Die Mutationsmethoden (`save`, `update`, `destroy` sowie die statischen `create`, `update`, `delete`) akzeptieren als letztes Argument ein optionales `options`-Objekt vom Typ `MutationOptions`:
+>
+> ```typescript
+> interface MutationOptions {
+>   hook?: boolean;          // Lifecycle-Hooks ausführen
+>   tx?: TransactionContext; // Operation innerhalb einer Transaktion ausführen
+> }
+> ```
+>
+> Mit `{ hook: true }` werden die Lifecycle-Hook-Dekoratoren (`@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy`, `@AfterDestroy`) der Entität ausgeführt.
+
+### `save(options?: MutationOptions): Promise<boolean>`
 
 Speichert oder aktualisiert den aktuellen Datensatz in der Datenbank.
+
+**Parameter:**
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Verhalten:**
 - Wenn der Datensatz keine `id` hat (oder sie `null`/`undefined` ist), erstellt er einen neuen Datensatz
@@ -111,12 +125,13 @@ await user.save(); // Nur updatedAt wird aktualisiert
 
 ---
 
-### `update(patch: Partial<InferAttributes<T>>): Promise<boolean>`
+### `update(patch: Partial<InferAttributes<T>>, options?: MutationOptions): Promise<boolean>`
 
 Aktualisiert den Datensatz teilweise mit den bereitgestellten Feldern.
 
 **Parameter:**
 - `patch` - Objekt mit den zu aktualisierenden Feldern
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Rückgabe:** `true` wenn die Operation erfolgreich war
 
@@ -135,9 +150,12 @@ console.log(user.age);  // 31
 
 ---
 
-### `destroy(): Promise<null>`
+### `destroy(options?: MutationOptions): Promise<null>`
 
 Löscht den aktuellen Datensatz aus der Datenbank.
+
+**Parameter:**
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Anforderungen:**
 - Die Instanz muss eine gültige `id` haben
@@ -189,12 +207,13 @@ console.log(json);
 
 ## Statische Methoden
 
-### `create<M>(data: InferAttributes<M>): Promise<M>`
+### `create<M>(data: InferAttributes<M>, options?: MutationOptions): Promise<M>`
 
 Erstellt und persistiert einen neuen Datensatz in der Datenbank.
 
 **Parameter:**
 - `data` - Objekt mit den Attributen des neuen Datensatzes
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Merkmale:**
 - Erstellt eine neue Instanz
@@ -223,7 +242,7 @@ console.log(user.createdAt); // "2025-01-15T10:30:00.000Z"
 ```typescript
 @Name("users")
 class User extends Table<User> {
-  @Mutate(v => v.toLowerCase().trim())
+  @Set(v => v.toLowerCase().trim())
   @Validate(v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? true : "Email inválido")
   declare email: string;
 }
@@ -238,13 +257,14 @@ const user = await User.create({
 
 ---
 
-### `update<M>(updates: Partial<InferAttributes<M>>, filters: Partial<InferAttributes<M>>): Promise<number>`
+### `update<M>(updates: Partial<InferAttributes<M>>, filters: Partial<InferAttributes<M>>, options?: MutationOptions): Promise<number>`
 
 Aktualisiert mehrere Datensätze, die den Filtern entsprechen.
 
 **Parameter:**
 - `updates` - Objekt mit den zu aktualisierenden Feldern (`undefined`-Felder werden ignoriert)
 - `filters` - Objekt mit den Auswahlkriterien
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks einmal pro betroffener Entität ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Merkmale:**
 - Aktualisiert alle Datensätze, die den Filtern entsprechen
@@ -284,12 +304,13 @@ const inactiveCount = await User.update(
 
 ---
 
-### `delete<M>(filters: Partial<InferAttributes<M>>): Promise<number>`
+### `delete<M>(filters: Partial<InferAttributes<M>>, options?: MutationOptions): Promise<number>`
 
 Löscht Datensätze, die den Filtern entsprechen.
 
 **Parameter:**
 - `filters` - Objekt mit den Auswahlkriterien
+- `options` (`MutationOptions`, optional) - `{ hook?: boolean; tx?: TransactionContext }`. Mit `{ hook: true }` werden die Lifecycle-Hooks einmal pro betroffener Entität ausgeführt; mit `{ tx }` läuft die Operation innerhalb einer Transaktion.
 
 **Merkmale:**
 - Löscht alle Datensätze, die den Filtern entsprechen

--- a/docs/references/table.es.md
+++ b/docs/references/table.es.md
@@ -80,9 +80,26 @@ await user.save();
 
 ---
 
+## Opciones de Mutación
+
+Los métodos de mutación aceptan como último argumento un objeto `options` opcional de tipo `MutationOptions`:
+
+```typescript
+interface MutationOptions {
+  hook?: boolean;          // Ejecuta los lifecycle hooks del modelo
+  tx?: TransactionContext; // Asocia la operación a una transacción
+}
+```
+
+- Con `{ hook: true }` se ejecutan los [hooks de ciclo de vida](./decorators.md#decoradores-de-hooks-de-ciclo-de-vida) (`@BeforeCreate`, `@AfterUpdate`, etc.) declarados en el modelo.
+- Con `{ tx }` la operación se encola dentro de una transacción atómica.
+- `increment()` y `decrement()` aceptan `options` para `{ tx }`, pero **no** disparan hooks.
+
+---
+
 ## Métodos de Instancia
 
-### `save(): Promise<boolean>`
+### `save(options?: MutationOptions): Promise<boolean>`
 
 Guarda o actualiza el registro actual en la base de datos.
 
@@ -111,7 +128,7 @@ await user.save(); // Solo updatedAt se actualiza
 
 ---
 
-### `update(patch: Partial<InferAttributes<T>>): Promise<boolean>`
+### `update(patch: Partial<InferAttributes<T>>, options?: MutationOptions): Promise<boolean>`
 
 Actualiza parcialmente el registro con los campos proporcionados.
 
@@ -135,7 +152,7 @@ console.log(user.age);  // 31
 
 ---
 
-### `destroy(): Promise<null>`
+### `destroy(options?: MutationOptions): Promise<null>`
 
 Elimina el registro actual de la base de datos.
 
@@ -189,7 +206,7 @@ console.log(json);
 
 ## Métodos Estáticos
 
-### `create<M>(data: InferAttributes<M>): Promise<M>`
+### `create<M>(data: InferAttributes<M>, options?: MutationOptions): Promise<M>`
 
 Crea y persiste un nuevo registro en la base de datos.
 
@@ -223,7 +240,7 @@ console.log(user.createdAt); // "2025-01-15T10:30:00.000Z"
 ```typescript
 @Name("users")
 class User extends Table<User> {
-  @Mutate(v => v.toLowerCase().trim())
+  @Set(v => v.toLowerCase().trim())
   @Validate(v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? true : "Email inválido")
   declare email: string;
 }
@@ -238,7 +255,7 @@ const user = await User.create({
 
 ---
 
-### `update<M>(updates: Partial<InferAttributes<M>>, filters: Partial<InferAttributes<M>>): Promise<number>`
+### `update<M>(updates: Partial<InferAttributes<M>>, filters: Partial<InferAttributes<M>>, options?: MutationOptions): Promise<number>`
 
 Actualiza múltiples registros que coincidan con los filtros.
 
@@ -284,7 +301,7 @@ const inactiveCount = await User.update(
 
 ---
 
-### `delete<M>(filters: Partial<InferAttributes<M>>): Promise<number>`
+### `delete<M>(filters: Partial<InferAttributes<M>>, options?: MutationOptions): Promise<number>`
 
 Elimina registros que coincidan con los filtros.
 

--- a/docs/references/table.md
+++ b/docs/references/table.md
@@ -244,13 +244,24 @@ console.log(json);
 
 ## Static Methods
 
-### `create<M>(data: InferAttributes<M>, tx?: TransactionContext): Promise<M>`
+The mutation methods (`create`, `update`, `delete`, `increment`, `decrement`) accept an optional `options` object as their last argument:
+
+```typescript
+type MutationOptions = {
+  hook?: boolean;          // Run lifecycle hooks for the operation (default: false)
+  tx?: TransactionContext; // Execute within an atomic transaction
+};
+```
+
+When called with `{ hook: true }`, the matching lifecycle hooks (`@BeforeCreate`, `@AfterCreate`, etc.) run around the operation. `increment()` and `decrement()` also accept `options` (the `tx` field), but never trigger hooks.
+
+### `create<M>(data: InferAttributes<M>, options?: MutationOptions): Promise<M>`
 
 Creates and persists a new record in the database.
 
 **Parameters:**
 - `data` - Object with the attributes for the new record
-- `tx` - (Optional) Transaction context for atomic operations
+- `options` - (Optional) Mutation options: `{ hook?, tx? }`
 
 **Characteristics:**
 - Creates a new instance
@@ -276,14 +287,14 @@ console.log(user.created_at); // "2025-01-15T10:30:00.000Z"
 
 ---
 
-### `update<M>(updates, filters, tx?: TransactionContext): Promise<number>`
+### `update<M>(updates, filters, options?: MutationOptions): Promise<number>`
 
 Updates multiple records matching the filters.
 
 **Parameters:**
 - `updates` - Object with fields to update
 - `filters` - Object with selection criteria
-- `tx` - (Optional) Transaction context for atomic operations
+- `options` - (Optional) Mutation options: `{ hook?, tx? }`
 
 **Returns:** Number of updated records
 
@@ -300,13 +311,13 @@ console.log(`${count} users suspended`);
 
 ---
 
-### `delete<M>(filters, tx?: TransactionContext): Promise<number>`
+### `delete<M>(filters, options?: MutationOptions): Promise<number>`
 
 Deletes records matching the filters.
 
 **Parameters:**
 - `filters` - Object with selection criteria
-- `tx` - (Optional) Transaction context for atomic operations
+- `options` - (Optional) Mutation options: `{ hook?, tx? }`
 
 **Returns:** Number of deleted records
 

--- a/docs/references/types.de.md
+++ b/docs/references/types.de.md
@@ -44,7 +44,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // Automatisch generierter Primärschlüssel
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Pflichtfeld (ohne CreationOptional)
@@ -69,7 +68,7 @@ const user = await User.create({
 });
 
 // Nach der Erstellung sind alle Felder vorhanden
-console.log(user.id);         // "550e8400-e29b-..."
+console.log(user.id);         // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 console.log(user.role);       // "customer"
 console.log(user.created_at); // "2025-01-15T10:30:00.000Z"
 ```

--- a/docs/references/types.es.md
+++ b/docs/references/types.es.md
@@ -44,7 +44,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // Clave primaria auto-generada
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Campo requerido (sin CreationOptional)

--- a/docs/references/types.md
+++ b/docs/references/types.md
@@ -44,7 +44,6 @@ import { Table, PrimaryKey, Default, CreatedAt, UpdatedAt, CreationOptional } fr
 class User extends Table<User> {
   // Auto-generated primary key
   @PrimaryKey()
-  @Default(() => crypto.randomUUID())
   declare id: CreationOptional<string>;
 
   // Required field (no CreationOptional)
@@ -69,7 +68,7 @@ const user = await User.create({
 });
 
 // After creation, all fields are present
-console.log(user.id);         // "550e8400-e29b-..."
+console.log(user.id);         // "01ARZ3NDEKTSV4RRFFQ69G5FAV"
 console.log(user.role);       // "customer"
 console.log(user.created_at); // "2025-01-15T10:30:00.000Z"
 ```

--- a/package.json
+++ b/package.json
@@ -69,5 +69,5 @@
     "release": "npm publish --access public"
   },
   "types": "./build/esm/index.d.ts",
-  "version": "2.1.0"
+  "version": "3.0.0"
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -366,7 +366,7 @@ export const requireClient = (): DynamoDBClient => {
  */
 export class TransactionContext {
   private operations: TransactionItem[] = [];
-  private after_commit: (() => void)[] = [];
+  private after_commit: (() => void | Promise<void>)[] = [];
   private client: DynamoDBClient;
 
   constructor(client: DynamoDBClient) {
@@ -412,10 +412,10 @@ export class TransactionContext {
   }
 
   /**
-   * @description Register a callback to run after successful commit.
-   * @description Registra un callback que se ejecuta después de un commit exitoso.
+   * @description Register a callback (sync or async) to run after successful commit.
+   * @description Registra un callback (síncrono o asíncrono) que se ejecuta después de un commit exitoso.
    */
-  onCommit(fn: () => void): void {
+  onCommit(fn: () => void | Promise<void>): void {
     this.after_commit.push(fn);
   }
 
@@ -430,7 +430,7 @@ export class TransactionContext {
       );
     }
 
-    for (const fn of this.after_commit) fn();
+    for (const fn of this.after_commit) await fn();
   }
 
   private guard(): void {

--- a/src/core/decorator.ts
+++ b/src/core/decorator.ts
@@ -6,10 +6,20 @@
 
 export const SCHEMA = Symbol('dynamite:schema');
 
+/**
+ * @description Lifecycle hook types supported by models.
+ * @description Tipos de hooks de ciclo de vida soportados por los modelos.
+ */
+export type HookType =
+  | 'beforeCreate' | 'afterCreate'
+  | 'beforeUpdate' | 'afterUpdate'
+  | 'beforeDestroy' | 'afterDestroy';
+
 export interface Schema {
   name: string;
   primary_key: string;
   gsis: Set<string>;
+  hooks: Record<HookType, string[]>;
   columns: Record<string, {
     name: string;
     get: ((value: any) => any)[];
@@ -42,13 +52,27 @@ function toSnakePlural(str: string): string {
   return snake.endsWith("s") ? snake : snake + "s";
 }
 
-function resolve(target: any, propertyKey: string | symbol): [Schema, Schema['columns'][string]] {
-  const ctor = target.constructor;
+/**
+ * @description Get (or lazily create) the Schema bound to a model class, with columns and hooks initialized.
+ * @description Obtiene (o crea perezosamente) el Schema asociado a una clase de modelo, con columns y hooks inicializados.
+ * @param ctor Model class constructor / Constructor de la clase del modelo
+ */
+export function getSchema(ctor: any): Schema {
   if (!Object.prototype.hasOwnProperty.call(ctor, SCHEMA)) {
-    ctor[SCHEMA] = { name: toSnakePlural(ctor.name), primary_key: 'id', gsis: new Set(), columns: {} };
+    ctor[SCHEMA] = {
+      name: toSnakePlural(ctor.name),
+      primary_key: 'id',
+      gsis: new Set<string>(),
+      hooks: { beforeCreate: [], afterCreate: [], beforeUpdate: [], afterUpdate: [], beforeDestroy: [], afterDestroy: [] },
+      columns: {},
+    };
   }
+  return ctor[SCHEMA];
+}
+
+function resolve(target: any, propertyKey: string | symbol): [Schema, Schema['columns'][string]] {
+  const schema = getSchema(target.constructor);
   const key = String(propertyKey);
-  const schema: Schema = ctor[SCHEMA];
   schema.columns[key] ||= { name: key, get: [], set: [], store: {} };
   return [schema, schema.columns[key]];
 }

--- a/src/core/table.ts
+++ b/src/core/table.ts
@@ -21,7 +21,7 @@ import type {
 } from "../@types/index";
 import { processIncludes } from "../utils/relations";
 import { requireClient, TransactionContext } from "./client";
-import type { Schema } from "./decorator";
+import type { HookType, Schema } from "./decorator";
 import { SCHEMA } from "./decorator";
 
 const OP_MAP: Record<string, string> = {
@@ -38,6 +38,21 @@ type WhereFilters<M> = {
   | InferAttributes<M>[K]
   | { [N in QueryOperator]?: InferAttributes<M>[K] };
 };
+
+/**
+ * @description Lifecycle hook signature. `this` is the model instance; update hooks receive the changes delta.
+ * @description Firma de un hook de ciclo de vida. `this` es la instancia del modelo; los hooks de update reciben el delta de cambios.
+ */
+export type HookFn<T = any> = (this: T, changes?: Partial<InferAttributes<T>>) => void | Promise<void>;
+
+/**
+ * @description Options for mutation operations. `hook` is opt-in (default false); `tx` runs the operation inside a transaction.
+ * @description Opciones para operaciones de mutación. `hook` es opt-in (default false); `tx` ejecuta la operación dentro de una transacción.
+ */
+export interface MutationOptions {
+  hook?: boolean;
+  tx?: TransactionContext;
+}
 
 export default class Table<T = any> {
   static [SCHEMA]: Schema;
@@ -182,26 +197,35 @@ export default class Table<T = any> {
     return JSON.stringify(this);
   }
 
-  public async save(): Promise<boolean> {
+  public async save(options?: MutationOptions): Promise<boolean> {
     const schema: Schema = (this.constructor as any)[SCHEMA];
-    const payload = (this as any)._toDBPayload();
+    const tx = options?.tx;
 
     if ((this as any).__isPersisted) {
-      await requireClient().send(
-        new PutItemCommand({
-          TableName: schema.name,
-          Item: marshall(payload, { removeUndefinedValues: true }),
-        })
-      );
+      if (options?.hook) await Table._run_hooks(this, 'beforeUpdate', {});
+      if (tx) {
+        tx.addPut(schema.name, (this as any)._toDBPayload());
+        if (options?.hook) tx.onCommit(() => Table._run_hooks(this, 'afterUpdate', {}));
+      } else {
+        await requireClient().send(
+          new PutItemCommand({
+            TableName: schema.name,
+            Item: marshall((this as any)._toDBPayload(), { removeUndefinedValues: true }),
+          })
+        );
+        if (options?.hook) await Table._run_hooks(this, 'afterUpdate', {});
+      }
       return true;
     }
 
+    if (options?.hook) await Table._run_hooks(this, 'beforeCreate');
     const created = await (this.constructor as any).create(
       Object.fromEntries(
         Object.keys(schema.columns)
           .filter(k => !schema.columns[k].store?.relation)
           .map(k => [k, (this as any)[k]])
-      )
+      ),
+      { hook: false, tx }
     );
     for (const key in schema.columns) {
       if (!schema.columns[key].store?.relation) {
@@ -209,10 +233,11 @@ export default class Table<T = any> {
       }
     }
     (this as any).__isPersisted = true;
+    if (options?.hook) await Table._run_hooks(this, 'afterCreate');
     return true;
   }
 
-  public async update(data: Partial<InferAttributes<T>>): Promise<boolean> {
+  public async update(data: Partial<InferAttributes<T>>, options?: MutationOptions): Promise<boolean> {
     const schema = (this.constructor as any)[SCHEMA];
 
     // Filtrar relaciones (ignorarlas) en vez de lanzar error
@@ -225,9 +250,39 @@ export default class Table<T = any> {
       }
     }
 
+    // Ruta con hooks: aplicar cambios y persistir sobre esta misma instancia
+    if (options?.hook) {
+      for (const key in filtered_data) {
+        (this as any)[key] = filtered_data[key];
+      }
+      // Auto-renovar campos @UpdatedAt no incluidos en los cambios
+      for (const col_name in schema.columns) {
+        if (schema.columns[col_name].store?.updatedAt && !(col_name in filtered_data)) {
+          (this as any)[col_name] = undefined;
+        }
+      }
+
+      await Table._run_hooks(this, 'beforeUpdate', filtered_data);
+
+      const tx = options.tx;
+      if (tx) {
+        tx.addPut(schema.name, (this as any)._toDBPayload());
+        tx.onCommit(() => Table._run_hooks(this, 'afterUpdate', filtered_data));
+      } else {
+        await requireClient().send(
+          new PutItemCommand({
+            TableName: schema.name,
+            Item: marshall((this as any)._toDBPayload(), { removeUndefinedValues: true }),
+          })
+        );
+        await Table._run_hooks(this, 'afterUpdate', filtered_data);
+      }
+      return true;
+    }
+
     const affected = await (this.constructor as any).update(filtered_data, {
       [schema.primary_key]: (this as any)[schema.primary_key],
-    });
+    }, { tx: options?.tx });
 
     if (affected > 0) {
       // Actualizar la instancia con los nuevos valores (incluyendo updated_at)
@@ -239,35 +294,58 @@ export default class Table<T = any> {
     return affected > 0;
   }
 
-  public async destroy(): Promise<null> {
+  public async destroy(options?: MutationOptions): Promise<null> {
     const schema = (this.constructor as any)[SCHEMA];
     const id = (this as any)[schema.primary_key];
 
     if (!id) throw new Error("Cannot destroy record without ID");
 
+    if (options?.hook) await Table._run_hooks(this, 'beforeDestroy');
+
+    let soft_col: string | null = null;
     for (const column_name in schema.columns) {
-      if (schema.columns[column_name].store?.softDelete) {
-        (this as any)[column_name] = new Date().toISOString();
-        await this.save();
-        return null;
-      }
+      if (schema.columns[column_name].store?.softDelete) { soft_col = column_name; break; }
     }
 
-    return this.forceDestroy();
+    if (soft_col) {
+      (this as any)[soft_col] = new Date().toISOString();
+      await this.save({ tx: options?.tx });
+    } else {
+      await this.forceDestroy({ tx: options?.tx });
+    }
+
+    if (options?.hook) {
+      if (options.tx) options.tx.onCommit(() => Table._run_hooks(this, 'afterDestroy'));
+      else await Table._run_hooks(this, 'afterDestroy');
+    }
+
+    return null;
   }
 
-  public async forceDestroy(): Promise<null> {
+  public async forceDestroy(options?: MutationOptions): Promise<null> {
     const schema = (this.constructor as any)[SCHEMA];
     const id = (this as any)[schema.primary_key];
 
     if (!id) throw new Error("Cannot destroy record without ID");
 
-    await requireClient().send(
-      new DeleteItemCommand({
-        TableName: schema.name,
-        Key: marshall({ [schema.primary_key]: id }),
-      })
-    );
+    if (options?.hook) await Table._run_hooks(this, 'beforeDestroy');
+
+    const tx = options?.tx;
+    if (tx) {
+      tx.addDelete(schema.name, { [schema.primary_key]: id });
+    } else {
+      await requireClient().send(
+        new DeleteItemCommand({
+          TableName: schema.name,
+          Key: marshall({ [schema.primary_key]: id }),
+        })
+      );
+    }
+
+    if (options?.hook) {
+      if (tx) tx.onCommit(() => Table._run_hooks(this, 'afterDestroy'));
+      else await Table._run_hooks(this, 'afterDestroy');
+    }
 
     return null;
   }
@@ -473,13 +551,27 @@ export default class Table<T = any> {
     }
   }
 
+  /**
+   * @description Run the registered hooks of a given type on an instance, in declaration order.
+   * @description Ejecuta los hooks registrados de un tipo dado sobre una instancia, en orden de declaración.
+   */
+  private static async _run_hooks(instance: any, type: HookType, changes?: any): Promise<void> {
+    const schema: Schema = (instance.constructor as any)[SCHEMA];
+    for (const method_name of schema.hooks[type]) {
+      await instance[method_name]?.(changes);
+    }
+  }
+
   static async create<M extends Table>(
     this: new (data: any) => M,
     data: Partial<InferAttributes<M>>,
-    tx?: TransactionContext
+    options?: MutationOptions
   ): Promise<M> {
     const instance = new this(data);
     const schema = (this as any)[SCHEMA];
+    const tx = options?.tx;
+
+    if (options?.hook) await Table._run_hooks(instance, 'beforeCreate');
 
     const payload = (instance as any)._toDBPayload();
     const pk_db_name = schema.columns[schema.primary_key]?.name || schema.primary_key;
@@ -491,6 +583,7 @@ export default class Table<T = any> {
     if (tx) {
       tx.addPut(schema.name, payload, condition);
       tx.onCommit(() => { (instance as any).__isPersisted = true; });
+      if (options?.hook) tx.onCommit(() => Table._run_hooks(instance, 'afterCreate'));
     } else {
       try {
         await requireClient().send(
@@ -508,6 +601,7 @@ export default class Table<T = any> {
         throw e;
       }
       (instance as any).__isPersisted = true;
+      if (options?.hook) await Table._run_hooks(instance, 'afterCreate');
     }
 
     return instance;
@@ -536,9 +630,10 @@ export default class Table<T = any> {
     this: new (data: any) => M,
     updates: Partial<InferAttributes<M>>,
     filters: Partial<InferAttributes<M>>,
-    tx?: TransactionContext
+    options?: MutationOptions
   ): Promise<number> {
     const schema: Schema = (this as any)[SCHEMA];
+    const tx = options?.tx;
 
     const parsed_updates: any = {};
     for (const key in updates) {
@@ -586,8 +681,11 @@ export default class Table<T = any> {
         }
       }
 
+      if (options?.hook) await Table._run_hooks(record, 'beforeUpdate', parsed_updates);
+
       if (tx) {
         tx.addPut(schema.name, (record as any)._toDBPayload());
+        if (options?.hook) tx.onCommit(() => Table._run_hooks(record, 'afterUpdate', parsed_updates));
       } else {
         await requireClient().send(
           new PutItemCommand({
@@ -595,6 +693,7 @@ export default class Table<T = any> {
             Item: marshall((record as any)._toDBPayload(), { removeUndefinedValues: true }),
           })
         );
+        if (options?.hook) await Table._run_hooks(record, 'afterUpdate', parsed_updates);
       }
     }
 
@@ -604,15 +703,17 @@ export default class Table<T = any> {
   static async delete<M extends Table>(
     this: new (data: any) => M,
     filters: Partial<InferAttributes<M>>,
-    tx?: TransactionContext
+    options?: MutationOptions
   ): Promise<number> {
     const schema: Schema = (this as any)[SCHEMA];
+    const tx = options?.tx;
 
-    // Optimización: si el filtro es PK exacta y no hay softDelete, DeleteItem directo
+    // Optimización: si el filtro es PK exacta, sin softDelete y sin hooks de destroy, DeleteItem directo
     const pk_value = (this as any)._extractPK(filters);
     const has_soft_delete = Object.values(schema.columns).some(c => c.store.softDelete);
+    const has_destroy_hooks = !!options?.hook && (schema.hooks.beforeDestroy.length > 0 || schema.hooks.afterDestroy.length > 0);
 
-    if (pk_value !== null && !has_soft_delete) {
+    if (pk_value !== null && !has_soft_delete && !has_destroy_hooks) {
       if (tx) {
         tx.addDelete(schema.name, { [schema.primary_key]: pk_value });
       } else {
@@ -634,8 +735,11 @@ export default class Table<T = any> {
       const id = (record as any)[schema.primary_key];
       if (!id) continue;
 
+      if (options?.hook) await Table._run_hooks(record, 'beforeDestroy');
+
       if (tx) {
         tx.addDelete(schema.name, { [schema.primary_key]: id });
+        if (options?.hook) tx.onCommit(() => Table._run_hooks(record, 'afterDestroy'));
       } else {
         await requireClient().send(
           new DeleteItemCommand({
@@ -643,6 +747,7 @@ export default class Table<T = any> {
             Key: marshall({ [schema.primary_key]: id }),
           })
         );
+        if (options?.hook) await Table._run_hooks(record, 'afterDestroy');
       }
     }
 
@@ -714,9 +819,9 @@ export default class Table<T = any> {
     field: keyof PickByType<InferAttributes<M>, number>,
     amount: number,
     filters: WhereFilters<M>,
-    tx?: TransactionContext
+    options?: MutationOptions
   ): Promise<number> {
-    return Table._atomicAdd(this, field as string, amount, filters as any, tx);
+    return Table._atomicAdd(this, field as string, amount, filters as any, options?.tx);
   }
 
   static async decrement<M extends Table>(
@@ -724,9 +829,9 @@ export default class Table<T = any> {
     field: keyof PickByType<InferAttributes<M>, number>,
     amount: number,
     filters: WhereFilters<M>,
-    tx?: TransactionContext
+    options?: MutationOptions
   ): Promise<number> {
-    return Table._atomicAdd(this, field as string, -amount, filters as any, tx);
+    return Table._atomicAdd(this, field as string, -amount, filters as any, options?.tx);
   }
 
   public async increment<K extends keyof PickByType<InferAttributes<T>, number>>(

--- a/src/decorators/hooks.ts
+++ b/src/decorators/hooks.ts
@@ -1,0 +1,55 @@
+/**
+ * @file hooks.ts
+ * @description Lifecycle hook decorators: @BeforeCreate, @AfterCreate, @BeforeUpdate, @AfterUpdate, @BeforeDestroy, @AfterDestroy
+ * @description Decoradores de hooks de ciclo de vida: @BeforeCreate, @AfterCreate, @BeforeUpdate, @AfterUpdate, @BeforeDestroy, @AfterDestroy
+ */
+
+import { getSchema } from "../core/decorator";
+import type { HookType } from "../core/decorator";
+
+/**
+ * @description Builds a method decorator that registers the method as a lifecycle hook of the given type.
+ * @description Construye un decorador de método que registra el método como hook de ciclo de vida del tipo dado.
+ * @param type Lifecycle hook type / Tipo de hook de ciclo de vida
+ */
+function hook(type: HookType) {
+  return () => (target: any, property_key: string | symbol): void => {
+    getSchema(target.constructor).hooks[type].push(String(property_key));
+  };
+}
+
+/**
+ * @description Runs before the record is created (opt-in via { hook: true }). `this` is the instance and may be mutated.
+ * @description Se ejecuta antes de crear el registro (opt-in con { hook: true }). `this` es la instancia y puede mutarse.
+ */
+export const BeforeCreate = hook('beforeCreate');
+
+/**
+ * @description Runs after the record is created (opt-in via { hook: true }). `this` is the persisted instance.
+ * @description Se ejecuta después de crear el registro (opt-in con { hook: true }). `this` es la instancia persistida.
+ */
+export const AfterCreate = hook('afterCreate');
+
+/**
+ * @description Runs before the record is updated (opt-in via { hook: true }). Receives the changes delta as argument.
+ * @description Se ejecuta antes de actualizar el registro (opt-in con { hook: true }). Recibe el delta de cambios como argumento.
+ */
+export const BeforeUpdate = hook('beforeUpdate');
+
+/**
+ * @description Runs after the record is updated (opt-in via { hook: true }). Receives the changes delta as argument.
+ * @description Se ejecuta después de actualizar el registro (opt-in con { hook: true }). Recibe el delta de cambios como argumento.
+ */
+export const AfterUpdate = hook('afterUpdate');
+
+/**
+ * @description Runs before the record is destroyed (opt-in via { hook: true }). `this` is the instance to remove.
+ * @description Se ejecuta antes de eliminar el registro (opt-in con { hook: true }). `this` es la instancia a eliminar.
+ */
+export const BeforeDestroy = hook('beforeDestroy');
+
+/**
+ * @description Runs after the record is destroyed (opt-in via { hook: true }). `this` is the removed instance.
+ * @description Se ejecuta después de eliminar el registro (opt-in con { hook: true }). `this` es la instancia eliminada.
+ */
+export const AfterDestroy = hook('afterDestroy');

--- a/src/decorators/transforms.ts
+++ b/src/decorators/transforms.ts
@@ -4,7 +4,7 @@
  * @description Decoradores primitivos: @Get, @Set, @Validate. Compuestos: @Default, @NotNull, @Name
  */
 
-import { decorator, SCHEMA } from "../core/decorator";
+import { decorator, getSchema } from "../core/decorator";
 
 /**
  * @description Output pipeline -- transforms value on read
@@ -86,7 +86,7 @@ export function Name(label: string): ClassDecorator & PropertyDecorator {
 
   return (target: any, prop?: string | symbol): void => {
     const ctor = prop === undefined ? target : target.constructor;
-    const schema = (ctor as any)[SCHEMA];
+    const schema = getSchema(ctor);
 
     if (prop === undefined) {
       schema.name = label;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,16 @@ export { Get, Set, Validate, Default, NotNull, Name } from "./decorators/transfo
 // Decoradores - Relaciones
 export { HasMany, BelongsTo, HasOne, ManyToMany } from "./decorators/relations";
 
+// Decoradores - Hooks de ciclo de vida
+export {
+  BeforeCreate, AfterCreate,
+  BeforeUpdate, AfterUpdate,
+  BeforeDestroy, AfterDestroy,
+} from "./decorators/hooks";
+
+// Tipos de hooks y opciones de mutación
+export type { MutationOptions, HookFn } from "./core/table";
+
 // Sistema de tipos simplificado
 export type {
   // Brands

--- a/src/test/basic.ts
+++ b/src/test/basic.ts
@@ -216,7 +216,7 @@ export default async function basic() {
 
   let tx_user: User | undefined;
   await dynamite.tx(async (tx) => {
-    tx_user = await User.create({ name: 'TxUser', email: 'tx@test.com' }, tx);
+    tx_user = await User.create({ name: 'TxUser', email: 'tx@test.com' }, { tx });
     assert('tx: instancia tiene id antes del commit', typeof tx_user!.id === 'string');
     assert('tx: __isPersisted es false antes del commit', (tx_user as any).__isPersisted === false);
   });
@@ -228,7 +228,7 @@ export default async function basic() {
   let tx_failed_user: User | undefined;
   try {
     await dynamite.tx(async (tx) => {
-      tx_failed_user = await User.create({ name: 'TxFail' }, tx);
+      tx_failed_user = await User.create({ name: 'TxFail' }, { tx });
       throw new Error('Rollback');
     });
   } catch {}

--- a/src/test/contracts.ts
+++ b/src/test/contracts.ts
@@ -156,8 +156,8 @@ export default async function contracts() {
 
   // Successful tx: both changes persist
   await dynamite.tx(async (tx) => {
-    await CUser.increment('score', 50, { id: u4.id }, tx);
-    await CUser.increment('score', 50, { id: u5.id }, tx);
+    await CUser.increment('score', 50, { id: u4.id }, { tx });
+    await CUser.increment('score', 50, { id: u5.id }, { tx });
   });
   const d_after = await CUser.first({ id: u4.id });
   const e_after = await CUser.first({ id: u5.id });
@@ -167,8 +167,8 @@ export default async function contracts() {
   // Failed tx: neither change persists
   try {
     await dynamite.tx(async (tx) => {
-      await CUser.increment('score', 1000, { id: u4.id }, tx);
-      await CPost.create({ title: 'orphan', user_id: u4.id }, tx);
+      await CUser.increment('score', 1000, { id: u4.id }, { tx });
+      await CPost.create({ title: 'orphan', user_id: u4.id }, { tx });
       throw new Error('Forced rollback');
     });
   } catch {}
@@ -182,7 +182,7 @@ export default async function contracts() {
   try {
     await dynamite.tx(async (tx) => {
       for (let i = 0; i < 5; i++) {
-        const p = await CPost.create({ title: `tx_post_${i}`, user_id: u4.id }, tx);
+        const p = await CPost.create({ title: `tx_post_${i}`, user_id: u4.id }, { tx });
         tx_ids.push(p.id);
       }
       throw new Error('Abort after 5 creates');
@@ -215,7 +215,7 @@ export default async function contracts() {
   // In tx before commit: false
   let tx_instance: CUser | undefined;
   await dynamite.tx(async (tx) => {
-    tx_instance = await CUser.create({ name: 'ivan' }, tx);
+    tx_instance = await CUser.create({ name: 'ivan' }, { tx });
     assert('in tx before commit: false', (tx_instance as any).__isPersisted === false);
   });
   assert('after tx commit: true', (tx_instance as any).__isPersisted === true);
@@ -224,7 +224,7 @@ export default async function contracts() {
   let failed_instance: CUser | undefined;
   try {
     await dynamite.tx(async (tx) => {
-      failed_instance = await CUser.create({ name: 'judy' }, tx);
+      failed_instance = await CUser.create({ name: 'judy' }, { tx });
       throw new Error('fail');
     });
   } catch {}

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -1,0 +1,154 @@
+import {
+  Dynamite, Table, PrimaryKey, Default, CreationOptional, Name, DeleteAt,
+  BeforeCreate, AfterCreate, BeforeUpdate, AfterUpdate, BeforeDestroy, AfterDestroy,
+} from "../index";
+
+const calls: string[] = [];
+
+@Name('test_hook_users')
+class HUser extends Table<HUser> {
+  @PrimaryKey()
+  declare id: CreationOptional<string>;
+  @Default('') declare name: string;
+  @Default('') declare slug: string;
+  @Default(() => 0) declare version: CreationOptional<number>;
+  @DeleteAt() declare deleted_at: CreationOptional<string>;
+
+  // Dos @BeforeCreate para validar el orden de ejecución (declaración top-to-bottom)
+  @BeforeCreate()
+  fill_slug() { this.slug = String(this.name).toLowerCase(); calls.push('beforeCreate'); }
+
+  @BeforeCreate()
+  mark_create() { calls.push('beforeCreate2'); }
+
+  @AfterCreate()
+  after_create() { calls.push('afterCreate'); }
+
+  @BeforeUpdate()
+  before_update(changes: any) { calls.push('beforeUpdate:' + Object.keys(changes ?? {}).sort().join(',')); }
+
+  @AfterUpdate()
+  after_update() { calls.push('afterUpdate'); }
+
+  @BeforeDestroy()
+  before_destroy() { calls.push('beforeDestroy'); }
+
+  @AfterDestroy()
+  after_destroy() { calls.push('afterDestroy'); }
+}
+
+let passed = 0;
+let failed = 0;
+function assert(label: string, condition: boolean, detail?: string) {
+  if (condition) { console.log(`  OK  ${label}`); passed++; }
+  else { console.error(`  FAIL  ${label}${detail ? ` -- ${detail}` : ''}`); failed++; }
+}
+
+export default async function hooks() {
+  console.log('\n=== HOOKS ===\n');
+
+  const dynamite = new Dynamite({
+    tables: [HUser],
+    region: 'local',
+    endpoint: 'http://localhost:8000',
+    credentials: { accessKeyId: 'local', secretAccessKey: 'local' },
+  });
+  await dynamite.connect();
+  await dynamite.sync();
+
+  // =====================================================
+  // 1. Opt-in vs opt-out en create
+  // =====================================================
+  console.log('-- create opt-in / opt-out --');
+
+  calls.length = 0;
+  const u_no = await HUser.create({ name: 'Ann' });
+  assert('create sin hook: no ejecuta hooks', calls.length === 0);
+  assert('create sin hook: beforeCreate no mutó slug', u_no.slug === '');
+
+  calls.length = 0;
+  const u_yes = await HUser.create({ name: 'Bob' }, { hook: true });
+  assert('create con hook: orden beforeCreate -> beforeCreate2 -> afterCreate',
+    JSON.stringify(calls) === JSON.stringify(['beforeCreate', 'beforeCreate2', 'afterCreate']),
+    JSON.stringify(calls));
+  assert('create con hook: beforeCreate mutó slug en la instancia', u_yes.slug === 'bob');
+  const u_yes_db = await HUser.first({ id: u_yes.id });
+  assert('create con hook: mutación persistida', u_yes_db?.slug === 'bob');
+
+  // =====================================================
+  // 2. Update de instancia
+  // =====================================================
+  console.log('\n-- instance update --');
+
+  calls.length = 0;
+  await u_yes.update({ name: 'Bobby' }, { hook: true });
+  assert('instance update con hook: beforeUpdate recibe changes', calls.includes('beforeUpdate:name'));
+  assert('instance update con hook: afterUpdate ejecutado', calls.includes('afterUpdate'));
+  const bobby = await HUser.first({ id: u_yes.id });
+  assert('instance update con hook: persistido', bobby?.name === 'Bobby');
+
+  calls.length = 0;
+  await u_yes.update({ name: 'Bib' });
+  assert('instance update sin hook: no ejecuta hooks', calls.length === 0);
+  const bib = await HUser.first({ id: u_yes.id });
+  assert('instance update sin hook: persistido igual', bib?.name === 'Bib');
+
+  // =====================================================
+  // 3. Update estático masivo: una vez por entidad
+  // =====================================================
+  console.log('\n-- static update masivo --');
+
+  await HUser.create({ name: 'batch' });
+  await HUser.create({ name: 'batch' });
+
+  calls.length = 0;
+  const affected = await HUser.update({ version: 7 }, { name: 'batch' } as any, { hook: true });
+  const before_count = calls.filter(c => c.startsWith('beforeUpdate')).length;
+  const after_count = calls.filter(c => c === 'afterUpdate').length;
+  assert('static update masivo: afecta 2 registros', affected === 2);
+  assert('static update masivo: beforeUpdate por entidad', before_count === 2);
+  assert('static update masivo: afterUpdate por entidad', after_count === 2);
+
+  // =====================================================
+  // 4. Destroy de instancia (soft delete)
+  // =====================================================
+  console.log('\n-- instance destroy (soft) --');
+
+  calls.length = 0;
+  await u_yes.destroy({ hook: true });
+  assert('instance destroy con hook: beforeDestroy + afterDestroy', calls.includes('beforeDestroy') && calls.includes('afterDestroy'));
+  const after_soft = await HUser.where({ id: u_yes.id });
+  assert('instance destroy: excluido de where (soft delete)', after_soft.length === 0);
+
+  // =====================================================
+  // 5. Delete estático con hooks de destroy
+  // =====================================================
+  console.log('\n-- static delete --');
+
+  const del_user = await HUser.create({ name: 'to_delete' });
+  calls.length = 0;
+  const deleted = await HUser.delete({ id: del_user.id } as any, { hook: true });
+  assert('static delete con hook: retorna 1', deleted === 1);
+  assert('static delete con hook: beforeDestroy + afterDestroy', calls.includes('beforeDestroy') && calls.includes('afterDestroy'));
+  const del_check = await HUser.where({ id: del_user.id }, { _includeTrashed: true });
+  assert('static delete con hook: eliminado (hard)', del_check.length === 0);
+
+  // =====================================================
+  // 6. Hooks dentro de una transacción
+  // =====================================================
+  console.log('\n-- hooks en transacción --');
+
+  calls.length = 0;
+  let tx_user: HUser | undefined;
+  await dynamite.tx(async (tx) => {
+    tx_user = await HUser.create({ name: 'TxHook' }, { hook: true, tx });
+    assert('tx: afterCreate aún no corre antes del commit', !calls.includes('afterCreate'));
+  });
+  assert('tx: beforeCreate corrió durante create', calls.includes('beforeCreate'));
+  assert('tx: afterCreate corrió tras el commit', calls.includes('afterCreate'));
+  const tx_db = await HUser.first({ id: tx_user!.id });
+  assert('tx: registro persistido con slug mutado', tx_db?.slug === 'txhook');
+
+  console.log(`\n  Hooks: ${passed} passed, ${failed} failed`);
+  return failed;
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -5,6 +5,7 @@ import filters from './filters';
 import bulk from './bulk';
 import query_scan from './query_scan';
 import contracts from './contracts';
+import hooks from './hooks';
 
 (async function () {
   try {
@@ -16,6 +17,7 @@ import contracts from './contracts';
     total_failures += await bulk();
     total_failures += await query_scan();
     total_failures += await contracts();
+    total_failures += await hooks();
 
     console.log(`\n${'='.repeat(40)}`);
     console.log(total_failures === 0

--- a/src/test/transactions.ts
+++ b/src/test/transactions.ts
@@ -45,8 +45,8 @@ export default async function transactions() {
   console.log('-- Multi-create --');
   let a1: Account | undefined, a2: Account | undefined;
   await dynamite.tx(async (tx) => {
-    a1 = await Account.create({ name: 'Alice', balance: 1000 }, tx);
-    a2 = await Account.create({ name: 'Bob', balance: 500 }, tx);
+    a1 = await Account.create({ name: 'Alice', balance: 1000 }, { tx });
+    a2 = await Account.create({ name: 'Bob', balance: 500 }, { tx });
   });
   assert('tx multi-create: ambos persistidos', (a1 as any).__isPersisted && (a2 as any).__isPersisted);
   const alice = await Account.first({ id: a1!.id });
@@ -58,8 +58,8 @@ export default async function transactions() {
   console.log('\n-- Create + increment --');
   let log1: TxLog | undefined;
   await dynamite.tx(async (tx) => {
-    log1 = await TxLog.create({ account_id: a1!.id, action: 'deposit', amount: 200 }, tx);
-    await Account.increment('balance', 200, { id: a1!.id }, tx);
+    log1 = await TxLog.create({ account_id: a1!.id, action: 'deposit', amount: 200 }, { tx });
+    await Account.increment('balance', 200, { id: a1!.id }, { tx });
   });
   const alice_after = await Account.first({ id: a1!.id });
   assert('tx increment: balance +200', alice_after?.balance === 1200);
@@ -70,10 +70,10 @@ export default async function transactions() {
   // -- Transferencia atomica (decrement + increment + log) --
   console.log('\n-- Transferencia atomica --');
   await dynamite.tx(async (tx) => {
-    await Account.decrement('balance', 300, { id: a1!.id }, tx);
-    await Account.increment('balance', 300, { id: a2!.id }, tx);
-    await TxLog.create({ account_id: a1!.id, action: 'transfer_out', amount: 300 }, tx);
-    await TxLog.create({ account_id: a2!.id, action: 'transfer_in', amount: 300 }, tx);
+    await Account.decrement('balance', 300, { id: a1!.id }, { tx });
+    await Account.increment('balance', 300, { id: a2!.id }, { tx });
+    await TxLog.create({ account_id: a1!.id, action: 'transfer_out', amount: 300 }, { tx });
+    await TxLog.create({ account_id: a2!.id, action: 'transfer_in', amount: 300 }, { tx });
   });
   const alice_transfer = await Account.first({ id: a1!.id });
   const bob_transfer = await Account.first({ id: a2!.id });
@@ -86,8 +86,8 @@ export default async function transactions() {
   let failed_account: Account | undefined;
   try {
     await dynamite.tx(async (tx) => {
-      failed_account = await Account.create({ name: 'Ghost' }, tx);
-      await Account.increment('balance', 99999, { id: a1!.id }, tx);
+      failed_account = await Account.create({ name: 'Ghost' }, { tx });
+      await Account.increment('balance', 99999, { id: a1!.id }, { tx });
       throw new Error('Simulated failure');
     });
   } catch {}
@@ -102,7 +102,7 @@ export default async function transactions() {
   const ids: string[] = [];
   await dynamite.tx(async (tx) => {
     for (let i = 0; i < 30; i++) {
-      const acc = await Account.create({ name: `Bulk_${i}`, balance: i }, tx);
+      const acc = await Account.create({ name: `Bulk_${i}`, balance: i }, { tx });
       ids.push(acc.id);
     }
   });


### PR DESCRIPTION
## Resumen

Agrega hooks de ciclo de vida a los modelos y unifica las opciones de las operaciones de mutación. Cambio incompatible → versión major **3.0.0**.

## Cambios

- **Hooks de ciclo de vida (opt-in)**: `@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDestroy`, `@AfterDestroy`. Se ejecutan solo con `{ hook: true }`. `this` es la entidad; los hooks de update reciben el delta. Varios del mismo tipo corren en orden de declaración; los async se esperan. Una vez por entidad en operaciones masivas.
- **Opciones de mutación unificadas (BREAKING)**: `create`, `update`, `delete`, `increment`, `decrement` (estáticos) y `save`, `update`, `destroy`, `forceDestroy` (instancia) reciben `{ hook?, tx? }` como último argumento. Se elimina el `tx` posicional (usar `{ tx }`).
- **`TransactionContext.onCommit`** acepta callbacks async.
- **Documentación**: `API.md` y `docs/` (EN/ES/DE) + changelog `3.0.0`. Corrección de deriva previa: decoradores eliminados `@Column`/`@Mutate`/`@Serialize` → `@Get`/`@Set`, y combos `@PrimaryKey`+`@Default` que rompían la validación ULID.
- **Versión**: `package.json` 3.0.0.

## Pruebas

Suite completa contra DynamoDB Local en verde, incluido `src/test/hooks.ts` (22/22). `tsc --noEmit` sin errores.

> Nota: no se creó issue porque el repositorio tiene los issues deshabilitados.